### PR TITLE
With multiple commands, the hook name should be unique to allow commands to run

### DIFF
--- a/charts/app/templates/hook.yaml
+++ b/charts/app/templates/hook.yaml
@@ -10,7 +10,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $release_name }}-{{ $hook.name }}
+  name: {{ $release_name }}-{{ $hook.name }}-{{ randAlphaNum 8 | lower }}
   labels:
     {{- if $app }}
     app_name: {{ $app.name }}


### PR DESCRIPTION
When using multiple commands to the hook, it seems that only the first one is created due to unique name violation. To fully support creating with multiple commands, the name should be unique.