### PR TITLE
fix(hook): The hook without the separator causes the hook to only execute once even with multiple commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29.14
-          - v1.30.10
-          - v1.31.6
+          - v1.29
+          - v1.30
+          - v1.31
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,9 +65,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29.14
-          - v1.30.10
-          - v1.31.6
+          - v1.29
+          - v1.30
+          - v1.31
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29
-          - v1.30
-          - v1.31
+          - v1.29.14
+          - v1.30.10
+          - v1.31.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.29
-          - v1.30
-          - v1.31
+          - v1.29.14
+          - v1.30.10
+          - v1.31.6
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.0"
+version: "1.2.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.2.1"
+version: "2.0.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.0.0"
+version: "1.2.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.0.0"

--- a/charts/app/templates/hook.yaml
+++ b/charts/app/templates/hook.yaml
@@ -7,6 +7,7 @@
 
 {{- if $hook -}}
 {{- range $command := .Values.hook.commands }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
@etowett seems the issue was a simple separator preventing the hooks from running correctly. Can you approve this for me? Doing a patch version bump alongside this.