### PR TITLE
fix rolling strategy to allow recreate

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.3.0"
+version: "1.3.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}
@@ -19,7 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "app.labels" . | nindent 8 }}
-	      {{- with .Values.podLabels }}
+        {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -33,6 +33,12 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+
 podSecurityContext:
   {}
   # fsGroup: 2000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New deployment strategy configuration options now available with RollingUpdate support, enabling customization of rollout behavior and control over maximum unavailable instances and surge replica settings.

* **Chores**
  * Chart version bumped to 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->