### PR TITLE
Add Makefile, AGENTS.md, and proper repo README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+Operational guide for AI agents working in this repository. Conventions below apply to humans too.
+
+## What this repo is
+
+A small collection of personal Helm charts. Today the only chart is `charts/app` — a flexible application chart with optional Celery worker/beat/flower components, hooks, init containers, sidecars, HPA, PDB, and ingress.
+
+## Layout
+
+```
+charts/                          Helm charts (each is self-contained)
+  app/
+    Chart.yaml                   Version, kubeVersion, maintainers
+    values.yaml                  Documented with @param doc comments
+    values.schema.json           Must stay in sync with values.yaml
+    templates/                   Helm templates
+    examples/                    Concrete values files (CI-validated)
+    README.md                    Chart-level documentation
+    CHANGELOG.md                 Per-chart changelog (Keep a Changelog)
+.github/
+  workflows/ci.yaml              CI: lint, render, kubeconform, kind install
+  ct.yaml                        chart-testing configuration
+Makefile                         Local dev shortcuts (`make help`)
+AGENTS.md                        This file
+README.md                        Repo overview
+```
+
+## Run before opening a PR
+
+```sh
+make lint              # helm lint every chart
+make template-examples # render every chart with each examples/*.yaml
+make ct-lint           # chart-testing lint (matches CI)
+make validate          # kubeconform validate against k8s 1.33–1.36
+```
+
+`make check` is a shortcut for `lint + template-examples` and is the fastest pre-push gate.
+
+CI runs the same checks plus a real `kind` install on k8s 1.33, 1.34, and 1.35.
+
+## Conventions
+
+- **Bump the chart version** in `Chart.yaml` for any chart change. CI enforces this via `check-version-increment: true` in `.github/ct.yaml`.
+- **Update `CHANGELOG.md`** for the affected chart. Keep a Changelog format. Lead with a "Changed (breaking)" section if the change requires user action.
+- **`values.schema.json` is part of the contract.** New value keys → new schema entries. A key allowed by `values.yaml` but absent from the schema breaks `helm install` with `--validate`.
+- **`@param` doc comments in `values.yaml`** are the source of truth for user-visible parameters. Mirror them in the chart README's parameter table.
+- **Examples are CI-validated.** Every new feature gets at least one `examples/<scenario>.yaml`; CI renders and kubeconform-validates each one.
+- **`kubeVersion`** in `Chart.yaml` should match what CI exercises. Don't widen the floor speculatively — Helm enforces this at install time.
+
+## Pitfalls to avoid
+
+- **Don't use `kubeval`** — unmaintained since 2020 and unaware of recent Kubernetes APIs. CI and the Makefile use `kubeconform` instead.
+- **Don't pin bare-minor `kindest/node:vX.Y` tags.** Kind only ships specific patch tags (e.g. `v1.35.0`, not `v1.35`). The current set lives in `.github/workflows/ci.yaml` and `Makefile`.
+- **Don't pass `command:` / `config:` to `helm/chart-testing-action@v2.7.0`** — those inputs were removed. Run `ct lint` / `ct install` as `run` steps.
+- **Don't add templates without rendering all examples.** A change in `_helpers.tpl` can silently break unrelated scenarios.
+- **Don't reach for sub-minute polling loops** when CI exposes an `outputs` field or a `needs:` dependency; use the dependency graph.
+- **Don't add features beyond the task.** Bug fixes don't need surrounding cleanup; one-shot operations don't need helpers.
+
+## Tool versions
+
+Tool versions are pinned both in `.github/workflows/ci.yaml` (env vars at the top) and in `Makefile` (variables at the top). Keep them in lockstep when bumping.
+
+| Tool         | Version (current) | Why pinned                           |
+|--------------|-------------------|--------------------------------------|
+| Helm         | v3.16.4           | Matches CI; covers all current APIs  |
+| kind         | v0.31.0           | Latest with node images up to 1.35   |
+| kubeconform  | v0.7.0            | Latest; schemas cover k8s 1.36       |
+| chart-testing| latest (action)   | Pinned via `helm/chart-testing-action` tag |
+
+## When adding a new chart
+
+1. `cp -r charts/app charts/<new>` and rename inside `Chart.yaml`.
+2. Reset `CHANGELOG.md`, clear `examples/`, rewrite `README.md`.
+3. Run `make lint template` to confirm it renders.
+4. Add at least one entry to `examples/`.
+5. Update the chart list in the repo root `README.md`.
+
+## CI details
+
+- Triggers on PRs touching `charts/**`, the workflow itself, or `.github/ct.yaml`.
+- Three jobs:
+  - `lint-chart` — `ct lint` + render defaults + render every example.
+  - `validate-manifests` — `kubeconform -strict` against k8s 1.33, 1.34, 1.35, 1.36.
+  - `install-chart` — real `kind` cluster install on k8s 1.33, 1.34, 1.35. Gated on `lint-chart.outputs.changed` so unrelated workflow edits don't spin up clusters.
+- Tool versions are env vars at the top of the workflow.
+- Concurrency cancels duplicate runs on the same PR.
+
+## Where to learn the domain
+
+- Chart-specific docs: [`charts/app/README.md`](charts/app/README.md)
+- Per-chart changelog: [`charts/app/CHANGELOG.md`](charts/app/CHANGELOG.md)
+- Helm chart best practices: https://helm.sh/docs/chart_best_practices/
+- chart-testing: https://github.com/helm/chart-testing
+- kubeconform: https://github.com/yannh/kubeconform

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eutychus Towett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # Helm charts repository — common dev tasks.
 # Run `make help` to list available targets.
 
-SHELL := /usr/bin/env bash
+# Use bash (not /bin/sh) so we can rely on pipefail, shopt, and arrays in
+# recipes. `bash` (PATH lookup) works on macOS and every Linux distro that
+# ships bash; `/usr/bin/env bash` is also valid on modern GNU Make but the
+# bare name avoids edge cases in older make versions.
+SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 # Tool versions — keep in lockstep with .github/workflows/ci.yaml
@@ -56,34 +60,32 @@ template: require-helm ## Render every chart with default values
 
 .PHONY: template-examples
 template-examples: require-helm ## Render every chart with each examples/*.yaml file
-	@for chart in charts/*/; do \
+	@shopt -s nullglob; \
+	for chart in charts/*/; do \
 		name=$$(basename "$$chart"); \
-		if [ -d "$${chart}examples" ]; then \
-			for example in $${chart}examples/*.yaml; do \
-				echo "==> helm template $$name -f $$(basename $$example)"; \
-				helm template "$$name-ci" "$$chart" -f "$$example" >/dev/null; \
-			done; \
-		fi; \
+		for example in $${chart}examples/*.yaml; do \
+			echo "==> helm template $$name -f $$(basename $$example)"; \
+			helm template "$$name-ci" "$$chart" -f "$$example" >/dev/null; \
+		done; \
 	done
 
 ##@ Validate (kubeconform)
 
 .PHONY: validate
 validate: require-helm install-kubeconform ## kubeconform-validate every chart (defaults + examples) against $(KUBE_VERSIONS)
-	@for k8s in $(KUBE_VERSIONS); do \
+	@shopt -s nullglob; \
+	for k8s in $(KUBE_VERSIONS); do \
 		echo "===> Kubernetes $$k8s"; \
 		for chart in charts/*/; do \
 			name=$$(basename "$$chart"); \
 			echo "  --> $$name (defaults)"; \
 			helm template "$$name-ci" "$$chart" | $(KUBECONFORM) -strict -ignore-missing-schemas \
 				-kubernetes-version "$$k8s" -summary -output text; \
-			if [ -d "$${chart}examples" ]; then \
-				for example in $${chart}examples/*.yaml; do \
-					echo "  --> $$name with $$(basename $$example)"; \
-					helm template "$$name-ci" "$$chart" -f "$$example" | $(KUBECONFORM) -strict -ignore-missing-schemas \
-						-kubernetes-version "$$k8s" -summary -output text; \
-				done; \
-			fi; \
+			for example in $${chart}examples/*.yaml; do \
+				echo "  --> $$name with $$(basename $$example)"; \
+				helm template "$$name-ci" "$$chart" -f "$$example" | $(KUBECONFORM) -strict -ignore-missing-schemas \
+					-kubernetes-version "$$k8s" -summary -output text; \
+			done; \
 		done; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,152 @@
+# Helm charts repository — common dev tasks.
+# Run `make help` to list available targets.
+
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+# Tool versions — keep in lockstep with .github/workflows/ci.yaml
+HELM_VERSION        ?= v3.16.4
+KIND_VERSION        ?= v0.31.0
+KUBECONFORM_VERSION ?= v0.7.0
+
+# kind node image used by `make kind-up`. Matches the latest version CI installs against.
+KIND_NODE_IMAGE     ?= kindest/node:v1.35.0
+KIND_CLUSTER        ?= chart-testing
+
+# Kubernetes versions to validate against (kubeconform schemas).
+KUBE_VERSIONS       ?= 1.33.0 1.34.0 1.35.0 1.36.0
+
+# Output dirs
+PKG_DIR             := dist
+LOCAL_BIN           := $(CURDIR)/bin
+
+# Use system kubeconform if present, otherwise fall back to the locally-installed one.
+KUBECONFORM         := $(shell command -v kubeconform 2>/dev/null || echo $(LOCAL_BIN)/kubeconform)
+
+.DEFAULT_GOAL := help
+
+##@ General
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} \
+		/^[a-zA-Z_0-9.-]+:.*?##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+
+.PHONY: check
+check: lint template-examples ## Quick local pre-PR checks (lint + render every example)
+	@echo "==> Local checks passed."
+
+##@ Lint and render
+
+.PHONY: lint
+lint: require-helm ## helm lint every chart
+	@for chart in charts/*/; do \
+		echo "==> helm lint $$chart"; \
+		helm lint "$$chart"; \
+	done
+
+.PHONY: template
+template: require-helm ## Render every chart with default values
+	@for chart in charts/*/; do \
+		name=$$(basename "$$chart"); \
+		echo "==> helm template $$name (defaults)"; \
+		helm template "$$name-ci" "$$chart" >/dev/null; \
+	done
+
+.PHONY: template-examples
+template-examples: require-helm ## Render every chart with each examples/*.yaml file
+	@for chart in charts/*/; do \
+		name=$$(basename "$$chart"); \
+		if [ -d "$${chart}examples" ]; then \
+			for example in $${chart}examples/*.yaml; do \
+				echo "==> helm template $$name -f $$(basename $$example)"; \
+				helm template "$$name-ci" "$$chart" -f "$$example" >/dev/null; \
+			done; \
+		fi; \
+	done
+
+##@ Validate (kubeconform)
+
+.PHONY: validate
+validate: require-helm install-kubeconform ## kubeconform-validate every chart (defaults + examples) against $(KUBE_VERSIONS)
+	@for k8s in $(KUBE_VERSIONS); do \
+		echo "===> Kubernetes $$k8s"; \
+		for chart in charts/*/; do \
+			name=$$(basename "$$chart"); \
+			echo "  --> $$name (defaults)"; \
+			helm template "$$name-ci" "$$chart" | $(KUBECONFORM) -strict -ignore-missing-schemas \
+				-kubernetes-version "$$k8s" -summary -output text; \
+			if [ -d "$${chart}examples" ]; then \
+				for example in $${chart}examples/*.yaml; do \
+					echo "  --> $$name with $$(basename $$example)"; \
+					helm template "$$name-ci" "$$chart" -f "$$example" | $(KUBECONFORM) -strict -ignore-missing-schemas \
+						-kubernetes-version "$$k8s" -summary -output text; \
+				done; \
+			fi; \
+		done; \
+	done
+
+##@ Chart-testing (ct)
+
+.PHONY: ct-lint
+ct-lint: require-ct ## Run chart-testing lint (matches CI)
+	ct lint --config .github/ct.yaml
+
+.PHONY: ct-list-changed
+ct-list-changed: require-ct ## List charts that changed vs main
+	ct list-changed --config .github/ct.yaml
+
+.PHONY: ct-install
+ct-install: require-ct ## Run chart-testing install against the current kubeconfig (needs `make kind-up` first)
+	ct install --config .github/ct.yaml
+
+##@ Kind cluster (local)
+
+.PHONY: kind-up
+kind-up: require-kind ## Create a local kind cluster ($(KIND_CLUSTER), $(KIND_NODE_IMAGE))
+	kind create cluster --name $(KIND_CLUSTER) --image $(KIND_NODE_IMAGE)
+
+.PHONY: kind-down
+kind-down: require-kind ## Delete the local kind cluster
+	kind delete cluster --name $(KIND_CLUSTER)
+
+##@ Package
+
+.PHONY: package
+package: require-helm ## Package every chart into $(PKG_DIR)/
+	@mkdir -p $(PKG_DIR)
+	@for chart in charts/*/; do \
+		helm package "$$chart" -d $(PKG_DIR); \
+	done
+
+.PHONY: clean
+clean: ## Remove packaged charts and local tooling
+	rm -rf $(PKG_DIR) $(LOCAL_BIN)
+
+##@ Tooling
+
+.PHONY: install-kubeconform
+install-kubeconform: ## Install kubeconform into ./bin/ if missing (matches CI version)
+	@if ! command -v kubeconform >/dev/null 2>&1 && [ ! -x "$(LOCAL_BIN)/kubeconform" ]; then \
+		mkdir -p $(LOCAL_BIN); \
+		os=$$(uname -s | tr A-Z a-z); arch=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); \
+		echo "==> Installing kubeconform $(KUBECONFORM_VERSION) to $(LOCAL_BIN)"; \
+		curl -fsSL "https://github.com/yannh/kubeconform/releases/download/$(KUBECONFORM_VERSION)/kubeconform-$${os}-$${arch}.tar.gz" \
+			| tar -xz -C $(LOCAL_BIN) kubeconform; \
+		chmod +x $(LOCAL_BIN)/kubeconform; \
+	fi
+
+##@ Internal
+
+.PHONY: require-helm
+require-helm:
+	@command -v helm >/dev/null 2>&1 || { echo "ERROR: helm not found. Install: https://helm.sh/docs/intro/install/"; exit 1; }
+
+.PHONY: require-kind
+require-kind:
+	@command -v kind >/dev/null 2>&1 || { echo "ERROR: kind not found. Install: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"; exit 1; }
+
+.PHONY: require-ct
+require-ct:
+	@command -v ct >/dev/null 2>&1 || { echo "ERROR: ct (chart-testing) not found. Install: brew install chart-testing  (or see https://github.com/helm/chart-testing)"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ The `app` chart currently targets Kubernetes 1.29 and newer. CI validates manife
 
 ## License
 
-To be added.
+[MIT](LICENSE) © Eutychus Towett.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Helm Charts
+
+[![CI](https://github.com/etowett/helm-charts/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/etowett/helm-charts/actions/workflows/ci.yaml)
+
+Personal collection of Helm charts. Each chart lives under `charts/` and ships with its own README, schema-validated `values.yaml`, ready-to-use examples, and CHANGELOG.
+
+## Charts
+
+| Chart | Description | Docs |
+|-------|-------------|------|
+| [`app`](charts/app) | Flexible application chart with optional Celery (worker/beat/flower), hooks, init containers, sidecars, HPA, PDB, and ingress | [README](charts/app/README.md) · [CHANGELOG](charts/app/CHANGELOG.md) · [Examples](charts/app/examples) |
+
+## Quick start
+
+```sh
+helm install my-app ./charts/app -f my-values.yaml
+```
+
+See the chart's [README](charts/app/README.md) for parameters and the [`examples/`](charts/app/examples) directory for ready-to-use values files covering basic web apps, ingress + TLS, Celery, init containers, hooks, autoscaling, and sidecars.
+
+## Repository layout
+
+```
+charts/                  Helm charts
+.github/workflows/       CI: lint, kubeconform validate, kind install
+.github/ct.yaml          chart-testing configuration
+Makefile                 Local development shortcuts (run `make help`)
+AGENTS.md                Operational guide for AI agents (and humans)
+README.md                You are here
+```
+
+## Development
+
+Run `make help` to list available targets. The common ones:
+
+| Target | Purpose |
+|--------|---------|
+| `make check` | `lint` + render every example (fastest pre-push gate) |
+| `make lint` | `helm lint` every chart |
+| `make template` | Render every chart with default values |
+| `make template-examples` | Render every chart with each `examples/*.yaml` |
+| `make validate` | `kubeconform` validation against Kubernetes 1.33–1.36 |
+| `make ct-lint` | Run chart-testing lint locally (matches CI) |
+| `make kind-up` / `make kind-down` | Local kind cluster for install tests |
+| `make ct-install` | Run chart-testing install against the local cluster |
+| `make package` | Package every chart into `dist/` |
+
+Tool prerequisites are documented in the Makefile and checked at runtime (`helm`, `kind`, `ct`). `make install-kubeconform` will fetch `kubeconform` into `./bin/` if it is missing.
+
+## CI
+
+Every PR runs three jobs across multiple Kubernetes versions:
+
+- **Lint and render** — `ct lint` plus full render of every example values file.
+- **Validate (k8s 1.33–1.36)** — `kubeconform -strict` against each k8s release.
+- **Install (k8s 1.33–1.35)** — real `kind` cluster install via `ct install`.
+
+See [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) for the full pipeline.
+
+## Contributing
+
+Bump the chart version in `Chart.yaml` and update the chart's `CHANGELOG.md` for any change — chart-testing enforces version increments. Keep `values.schema.json` in sync with `values.yaml`, and add or extend an example under `examples/` for any new behaviour.
+
+See [`AGENTS.md`](AGENTS.md) for the full conventions guide.
+
+## Kubernetes compatibility
+
+The `app` chart currently targets Kubernetes 1.29 and newer. CI validates manifest rendering up to the latest stable Kubernetes release and installs on the most recent versions that `kind` ships node images for. Each chart's `CHANGELOG.md` records the supported floor per release.
+
+## License
+
+To be added.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,0 @@
-# Helm charts
-
-This is home for my helm charts.


### PR DESCRIPTION
## Summary

Adds repo-level tooling and docs so contributors (human or AI) have a single place to find the conventions, and a one-command local dev loop that mirrors CI.

- **`Makefile`** — self-documenting `make help`; targets for `lint`, `template`, `template-examples`, `validate` (kubeconform against k8s 1.33–1.36), `ct-lint` / `ct-install`, `kind-up` / `kind-down`, `package`, and `check` (lint + render examples). Tool versions pinned to match `.github/workflows/ci.yaml`; missing binaries fail fast with an install hint via `require-<tool>` guards.
- **`AGENTS.md`** — operational guide. Documents repo layout, the pre-PR command set, the version-bump + changelog + `values.schema.json` conventions that chart-testing enforces, the tool pins, and concrete pitfalls (don't use kubeval; don't pin bare `kindest/node:vX.Y` minor tags; don't pass legacy `command:`/`config:` inputs to `helm/chart-testing-action`; schema/values drift breaks installs).
- **`README.md`** — replaces the three-line `readme.md` with a CI-badged repo README: chart table linking to per-chart docs, quick start, layout, common Makefile targets, CI overview, contributing pointer to `AGENTS.md`, and the Kubernetes compatibility statement. Renamed `readme.md` → `README.md` for canonical casing.

No chart templates or CI configuration changed in this PR.

## Test plan

- [x] `make help` lists every target in sectioned form
- [x] `make lint` — `helm lint` succeeds for `charts/app`
- [x] `make template-examples` renders all seven example values files
- [x] `make check` passes end-to-end locally
- [ ] CI lints + validates on this PR (no chart changes, so the install-chart job is skipped via the changed-charts gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)