### PR TITLE
app: expose startupProbe, HPA behavior/metrics, topologySpreadConstraints (v1.5.0)

### DIFF
--- a/charts/app/CHANGELOG.md
+++ b/charts/app/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-06-24
+
+### Added
+- `startupProbe` support on the main container and the optional `sidecarimage` container. Use this for slow-starting apps (JVM, Next.js, Rails eager-load) so the liveness probe — and the HPA's "Ready" gate — do not run during the boot window. Closes the long-standing `Future Plans` item.
+- `autoscaling.behavior` exposes the HorizontalPodAutoscaler v2 `behavior` block (`scaleUp` / `scaleDown` policies and `stabilizationWindowSeconds`). Without it, a single boot CPU burst against a small request can cascade into runaway scale-up. Mirrored on `celery.worker.autoscaling.behavior`.
+- `autoscaling.metrics` accepts a raw list of HPAv2 metric specs that is appended to the generated `metrics:` list. Use for absolute (`averageValue`) targets, Pods/Object/External metrics. Mirrored on `celery.worker.autoscaling.metrics`.
+- `topologySpreadConstraints` on the main deployment and on each celery deployment (`celery.worker`, `celery.beat`, `celery.flower`). String fields are processed through `tpl`, so `{{ .Release.Name }}` and similar template references resolve correctly. Closes the `Future Plans` item; preferred over `podAntiAffinity` since k8s 1.19 (default-on since 1.25).
+- New examples:
+  - `examples/with-startup-probe.yaml` — slow-booting app pattern.
+  - `examples/with-topology-spread.yaml` — modern node/zone spread.
+- `examples/with-autoscaling.yaml` extended to demonstrate `autoscaling.behavior`, `autoscaling.metrics`, and `topologySpreadConstraints`.
+
+### Changed
+- `autoscaling.targetCPUUtilizationPercentage` and `autoscaling.targetMemoryUtilizationPercentage` schema `maximum` raised from `100` to `1000` (and same for `celery.worker.autoscaling.*`). Utilization is a percentage of the container's resource *request*, and values above 100 are valid — common when the request is intentionally small and you want to absorb short bursts above the request before scaling out. Existing values are unchanged.
+
+### Notes
+All v1.5.0 additions are opt-in and default to empty/zero values, so existing values files render the same Kubernetes manifests as on 1.4.0. No migration is required.
+
 ## [1.4.0] - 2026-05-20
 
 ### Changed (breaking)
@@ -148,8 +166,6 @@ All changes in 1.0.0 through 1.3.x were backward compatible.
 
 ## Future Plans
 
-- Support for custom startup probes (Kubernetes 1.20+)
-- Support for topologySpreadConstraints
 - NetworkPolicy template
 - ServiceMonitor template for Prometheus Operator
 - Support for multiple init containers

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.4.0"
+version: "1.5.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -143,6 +143,15 @@ The following table lists the configurable parameters of the chart and their def
 | `readinessProbe.initialDelaySeconds` | Initial delay for readiness probe | - |
 | `readinessProbe.periodSeconds` | Period for readiness probe | - |
 | `readinessProbe.timeoutSeconds` | Timeout for readiness probe | - |
+| `startupProbe` | Startup probe configuration (empty `{}` disables the probe). Use for slow-starting apps so the liveness probe and HPA "Ready" gate are deferred until the app has reported healthy once. | `{}` |
+| `startupProbe.path` | Startup probe HTTP path | - |
+| `startupProbe.port` | Startup probe port | - |
+| `startupProbe.httpHeaders` | Startup probe HTTP headers | `[]` |
+| `startupProbe.initialDelaySeconds` | Seconds before first probe | - |
+| `startupProbe.periodSeconds` | Seconds between probes | - |
+| `startupProbe.timeoutSeconds` | Per-probe timeout in seconds | - |
+| `startupProbe.failureThreshold` | Consecutive failures before the container is restarted. Effective max boot time = `periodSeconds * failureThreshold`. | - |
+| `startupProbe.successThreshold` | Consecutive successes before the probe is considered started | - |
 
 ### Resources Parameters
 
@@ -157,8 +166,10 @@ The following table lists the configurable parameters of the chart and their def
 | `autoscaling.enabled` | Enable horizontal pod autoscaling | `false` |
 | `autoscaling.minReplicas` | Minimum number of replicas | `1` |
 | `autoscaling.maxReplicas` | Maximum number of replicas | `100` |
-| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization | `80` |
-| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `80` |
+| `autoscaling.targetCPUUtilizationPercentage` | Target average CPU utilization as a percentage of the container's CPU request. Values > 100 are valid when the request is intentionally small. | `80` |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target average memory utilization (% of request) | `80` |
+| `autoscaling.metrics` | Extra raw HPA v2 metric specs appended to the generated `metrics:` list. Use for `averageValue` targets, Pods/Object/External metrics. | `[]` |
+| `autoscaling.behavior` | HPA v2 `behavior` block (`scaleUp` / `scaleDown` policies + `stabilizationWindowSeconds`). Strongly recommended for apps with bursty boot-time CPU. | `{}` |
 
 ### Pod Disruption Budget Parameters
 
@@ -188,6 +199,7 @@ The following table lists the configurable parameters of the chart and their def
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity rules | `{}` |
+| `topologySpreadConstraints` | Pod topology spread constraints (preferred over `podAntiAffinity` since k8s 1.19+, default-on since 1.25). String fields are processed through `tpl`, so `{{ .Release.Name }}` resolves correctly. | `[]` |
 
 ### External Secrets Parameters
 
@@ -220,6 +232,7 @@ The following table lists the configurable parameters of the chart and their def
 | `sidecarimage.resources` | Sidecar resources | - |
 | `sidecarimage.livenessProbe` | Sidecar liveness probe | - |
 | `sidecarimage.readinessProbe` | Sidecar readiness probe | - |
+| `sidecarimage.startupProbe` | Sidecar startup probe (same shape as the main container's `startupProbe`) | - |
 
 ### Hook Parameters
 
@@ -255,11 +268,14 @@ The following table lists the configurable parameters of the chart and their def
 | `celery.worker.autoscaling.enabled` | Enable worker autoscaling | `false` |
 | `celery.worker.autoscaling.minReplicas` | Min worker replicas | `1` |
 | `celery.worker.autoscaling.maxReplicas` | Max worker replicas | `10` |
-| `celery.worker.autoscaling.targetCPUUtilizationPercentage` | Target CPU for worker | `80` |
-| `celery.worker.autoscaling.targetMemoryUtilizationPercentage` | Target memory for worker | `80` |
+| `celery.worker.autoscaling.targetCPUUtilizationPercentage` | Target CPU for worker (% of request, values > 100 allowed) | `80` |
+| `celery.worker.autoscaling.targetMemoryUtilizationPercentage` | Target memory for worker (% of request) | `80` |
+| `celery.worker.autoscaling.metrics` | Extra raw HPA v2 metric specs for the worker HPA | `[]` |
+| `celery.worker.autoscaling.behavior` | HPA v2 `behavior` block for the worker HPA | `{}` |
 | `celery.worker.nodeSelector` | Worker node selector | `{}` |
 | `celery.worker.tolerations` | Worker tolerations | `[]` |
 | `celery.worker.affinity` | Worker affinity | `{}` |
+| `celery.worker.topologySpreadConstraints` | Worker pod topology spread constraints (processed through `tpl`) | `[]` |
 | `celery.worker.podAnnotations` | Worker pod annotations | `{}` |
 | `celery.worker.podLabels` | Worker pod labels | `{}` |
 
@@ -274,6 +290,7 @@ The following table lists the configurable parameters of the chart and their def
 | `celery.beat.nodeSelector` | Beat node selector | `{}` |
 | `celery.beat.tolerations` | Beat tolerations | `[]` |
 | `celery.beat.affinity` | Beat affinity | `{}` |
+| `celery.beat.topologySpreadConstraints` | Beat pod topology spread constraints (processed through `tpl`) | `[]` |
 | `celery.beat.podAnnotations` | Beat pod annotations | `{}` |
 | `celery.beat.podLabels` | Beat pod labels | `{}` |
 
@@ -297,6 +314,7 @@ The following table lists the configurable parameters of the chart and their def
 | `celery.flower.nodeSelector` | Flower node selector | `{}` |
 | `celery.flower.tolerations` | Flower tolerations | `[]` |
 | `celery.flower.affinity` | Flower affinity | `{}` |
+| `celery.flower.topologySpreadConstraints` | Flower pod topology spread constraints (processed through `tpl`) | `[]` |
 | `celery.flower.podAnnotations` | Flower pod annotations | `{}` |
 | `celery.flower.podLabels` | Flower pod labels | `{}` |
 
@@ -512,6 +530,18 @@ sidecarimage:
 ```
 
 ## Upgrading
+
+### To 1.5.0
+
+Backward-compatible release. Existing values files render the same manifests they did on 1.4.0. New opt-in features:
+
+- `startupProbe` on the main container and on `sidecarimage`. Recommended for any app whose boot time is comparable to or larger than `livenessProbe.failureThreshold * livenessProbe.periodSeconds`.
+- `autoscaling.behavior` exposes the HPAv2 `behavior` block. Strongly recommended whenever boot CPU dwarfs steady-state CPU (Next.js, JVM, Rails eager-load) — without it, a single booting pod's CPU burst can cascade the HPA into runaway scale-up. Mirrored on `celery.worker.autoscaling.behavior`.
+- `autoscaling.metrics` accepts a raw list of HPAv2 metric specs (appended to the generated `metrics:`). Use for absolute (`averageValue`) targets and for Pods/Object/External metrics. Mirrored on `celery.worker.autoscaling.metrics`.
+- `topologySpreadConstraints` is now wired on the main deployment and on every celery deployment. Prefer this over `affinity.podAntiAffinity` for new deployments.
+- The schema `maximum` on `targetCPUUtilizationPercentage` / `targetMemoryUtilizationPercentage` (and the celery worker equivalents) was raised from `100` to `1000` to reflect that utilization is a percentage of the container's *request*, not of node capacity. Existing values are unchanged.
+
+See `examples/with-startup-probe.yaml`, `examples/with-topology-spread.yaml`, and the updated `examples/with-autoscaling.yaml` for ready-to-use snippets.
 
 ### To 1.4.0
 

--- a/charts/app/examples/README.md
+++ b/charts/app/examples/README.md
@@ -98,6 +98,37 @@ Application with a sidecar container:
 helm install my-app ./charts/app -f ./charts/app/examples/with-sidecar.yaml
 ```
 
+### 8. Application with Startup Probe
+**File:** `with-startup-probe.yaml`
+
+Slow-booting application (JVM, Next.js, Rails eager-load, Python ML
+imports). The startup probe defers liveness and the HPA "Ready" gate
+until the app reports healthy once, so:
+
+- A long boot does not trip `CrashLoopBackOff` under an aggressive
+  liveness probe.
+- The boot-time CPU burst is not mistaken for steady-state load by the
+  HPA, which would otherwise cascade into runaway scale-up.
+
+**Usage:**
+```bash
+helm install my-app ./charts/app -f ./charts/app/examples/with-startup-probe.yaml
+```
+
+### 9. Application with Topology Spread Constraints
+**File:** `with-topology-spread.yaml`
+
+Spread pods evenly across nodes and zones using
+`topologySpreadConstraints` — the modern Kubernetes-native replacement
+for `podAntiAffinity` (stable since 1.19, default-on since 1.25).
+String fields in the constraints are processed through `tpl`, so
+`{{ .Release.Name }}` and similar references resolve correctly.
+
+**Usage:**
+```bash
+helm install my-app ./charts/app -f ./charts/app/examples/with-topology-spread.yaml
+```
+
 ## Combining Examples
 
 You can combine multiple example files to use features from different examples:

--- a/charts/app/examples/with-autoscaling.yaml
+++ b/charts/app/examples/with-autoscaling.yaml
@@ -1,5 +1,8 @@
 # Application with Autoscaling and PDB Example
-# This example shows horizontal pod autoscaling and pod disruption budget
+# This example shows horizontal pod autoscaling and pod disruption budget,
+# plus the v1.5.0 additions: HPA `behavior` (to prevent boot-burst scale-up
+# cascades) and `topologySpreadConstraints` (modern replacement for the
+# podAntiAffinity-only approach).
 
 # Initial replica count (overridden when autoscaling is enabled)
 replicaCount: 3
@@ -25,6 +28,40 @@ autoscaling:
   maxReplicas: 20
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 80
+
+  # Extra raw HPA v2 metric specs. Useful for absolute targets
+  # (averageValue) or Pods/Object/External metrics. Each entry is
+  # appended to the generated metrics list.
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: "100"
+
+  # HPA v2 behavior. Without a custom behavior the controller's default
+  # `scaleUp.stabilizationWindowSeconds=0` lets a single boot burst
+  # cascade into runaway scale-up against a small CPU request. Slow the
+  # scale-up down and let scale-down breathe.
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
 
 # Enable pod disruption budget to ensure availability during voluntary disruptions
 pdb:
@@ -53,7 +90,27 @@ readinessProbe:
   periodSeconds: 5
   timeoutSeconds: 3
 
-# Node affinity to prefer specific node types
+# Topology spread is the modern Kubernetes-native way to spread pods.
+# Prefer this over `podAntiAffinity` for new deployments. labelSelector
+# values are processed through `tpl`, so {{ .Release.Name }} works.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+
+# Node affinity to prefer specific node types (kept for backward-compat).
+# topologySpreadConstraints above handles the "spread evenly" concern.
 affinity:
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
@@ -65,16 +122,3 @@ affinity:
               values:
                 - t3.large
                 - t3.xlarge
-
-# Add pod anti-affinity to spread pods across nodes
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - mywebapp
-          topologyKey: kubernetes.io/hostname

--- a/charts/app/examples/with-startup-probe.yaml
+++ b/charts/app/examples/with-startup-probe.yaml
@@ -1,0 +1,70 @@
+# Application with Startup Probe Example
+#
+# Use a startup probe for slow-starting applications: JVM warm-up,
+# Next.js initial build, Rails eager-load, Python apps that import
+# heavy ML libraries on boot, etc.
+#
+# Without a startup probe, the kubelet starts the liveness probe
+# countdown immediately. A slow boot then either:
+#   1. trips livenessProbe.failureThreshold and the kubelet restarts
+#      the container, producing CrashLoopBackOff, or
+#   2. completes after liveness has already counted enough failures
+#      that the deployment never reaches Ready and the HPA observes
+#      sustained "100% CPU usage" against a small request, triggering
+#      runaway scale-up.
+#
+# The startup probe lets the kubelet defer both liveness and the HPA's
+# "Ready" gate until the app reports healthy at least once. Effective
+# max boot time = periodSeconds * failureThreshold.
+#
+# Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
+
+replicaCount: 3
+
+image:
+  repository: myapp/web
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+app:
+  name: slow-starting-app
+  env: production
+  country: us
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 200m
+    memory: 512Mi
+
+# Aggressive liveness — safe to keep aggressive because the startup
+# probe below shields the boot window.
+livenessProbe:
+  path: /healthz
+  port: 8080
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 3
+
+readinessProbe:
+  path: /readyz
+  port: 8080
+  initialDelaySeconds: 0
+  periodSeconds: 5
+  timeoutSeconds: 3
+
+# Startup probe: allow up to 5 minutes (10s * 30) to boot. Once the
+# probe succeeds once, the kubelet stops running it and starts the
+# liveness/readiness probes normally.
+startupProbe:
+  path: /healthz
+  port: 8080
+  periodSeconds: 10
+  failureThreshold: 30
+  timeoutSeconds: 3

--- a/charts/app/examples/with-topology-spread.yaml
+++ b/charts/app/examples/with-topology-spread.yaml
@@ -1,0 +1,64 @@
+# Application with Topology Spread Constraints Example
+#
+# topologySpreadConstraints is the modern Kubernetes-native way to
+# spread pods evenly across failure domains. It has been stable since
+# v1.19 and the default Pod Topology Spread scheduler plugin has been
+# on by default since v1.25.
+#
+# Prefer it over `affinity.podAntiAffinity` for new deployments:
+#   - More expressive (maxSkew, multiple domains in one constraint)
+#   - Cheaper to evaluate at scheduling time
+#   - First-class support for `whenUnsatisfiable: ScheduleAnyway`
+#     (soft) vs `DoNotSchedule` (hard) per constraint
+#
+# References:
+#   - https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+#   - https://kubernetes.io/blog/2020/05/introducing-podtopologyspread/
+
+replicaCount: 6
+
+image:
+  repository: myapp/web
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+app:
+  name: spread-app
+  env: production
+  country: us
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Spread across both nodes and zones. Soft (ScheduleAnyway) so the
+# scheduler still places pods if the cluster cannot satisfy the
+# constraint — useful for clusters with heterogeneous node sizes
+# where a hard constraint would block scheduling.
+#
+# The labelSelector here uses the chart's standard selector labels.
+# String fields are processed through `tpl`, so `{{ .Release.Name }}`
+# resolves correctly.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: app
+        app.kubernetes.io/instance: "{{ .Release.Name }}"

--- a/charts/app/templates/celery-beat-deployment.yaml
+++ b/charts/app/templates/celery-beat-deployment.yaml
@@ -85,4 +85,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.celery.beat.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/app/templates/celery-flower-deployment.yaml
+++ b/charts/app/templates/celery-flower-deployment.yaml
@@ -89,4 +89,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.celery.flower.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/app/templates/celery-worker-deployment.yaml
+++ b/charts/app/templates/celery-worker-deployment.yaml
@@ -87,4 +87,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.celery.worker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/app/templates/celery-worker-hpa.yaml
+++ b/charts/app/templates/celery-worker-hpa.yaml
@@ -30,4 +30,11 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.celery.worker.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.celery.worker.autoscaling.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.celery.worker.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -87,6 +87,31 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: {{ .Values.startupProbe.port }}
+              {{- with .Values.startupProbe.httpHeaders }}
+              httpHeaders:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+            {{- with .Values.startupProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.startupProbe.periodSeconds }}
+            periodSeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.startupProbe.timeoutSeconds }}
+            timeoutSeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.startupProbe.failureThreshold }}
+            failureThreshold: {{ . }}
+            {{- end }}
+            {{- with .Values.startupProbe.successThreshold }}
+            successThreshold: {{ . }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
@@ -135,6 +160,27 @@ spec:
             initialDelaySeconds:  {{ .Values.sidecarimage.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sidecarimage.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.sidecarimage.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.sidecarimage.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.sidecarimage.startupProbe.path }}
+              port: {{ .Values.sidecarimage.startupProbe.port }}
+            {{- with .Values.sidecarimage.startupProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.sidecarimage.startupProbe.periodSeconds }}
+            periodSeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.sidecarimage.startupProbe.timeoutSeconds }}
+            timeoutSeconds: {{ . }}
+            {{- end }}
+            {{- with .Values.sidecarimage.startupProbe.failureThreshold }}
+            failureThreshold: {{ . }}
+            {{- end }}
+            {{- with .Values.sidecarimage.startupProbe.successThreshold }}
+            successThreshold: {{ . }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.sidecarimage.resources | nindent 12 }}
@@ -191,4 +237,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/charts/app/templates/hpa.yaml
+++ b/charts/app/templates/hpa.yaml
@@ -29,4 +29,11 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/app/values.schema.json
+++ b/charts/app/values.schema.json
@@ -235,6 +235,23 @@
       "type": ["object", "null"],
       "description": "Readiness probe configuration"
     },
+    "startupProbe": {
+      "type": ["object", "null"],
+      "description": "Startup probe configuration. Empty object disables the probe. Effective max boot time = periodSeconds * failureThreshold.",
+      "properties": {
+        "path": { "type": "string", "description": "HTTP path for the startup probe" },
+        "port": {
+          "oneOf": [{ "type": "integer", "minimum": 1, "maximum": 65535 }, { "type": "string" }],
+          "description": "Port number or named port"
+        },
+        "httpHeaders": { "type": "array", "items": { "type": "object" } },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 },
+        "successThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
     "autoscaling": {
       "type": "object",
       "properties": {
@@ -255,14 +272,23 @@
         "targetCPUUtilizationPercentage": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 100,
-          "description": "Target CPU utilization percentage"
+          "maximum": 1000,
+          "description": "Target CPU utilization as a percentage of the container's CPU request. Values >100 are valid and useful when the request is intentionally small."
         },
         "targetMemoryUtilizationPercentage": {
           "type": "integer",
           "minimum": 1,
-          "maximum": 100,
-          "description": "Target memory utilization percentage"
+          "maximum": 1000,
+          "description": "Target memory utilization as a percentage of the container's memory request"
+        },
+        "metrics": {
+          "type": "array",
+          "items": { "type": "object" },
+          "description": "Extra raw HPA v2 metric entries appended to the generated metrics list"
+        },
+        "behavior": {
+          "type": "object",
+          "description": "HPA v2 behavior block controlling scaleUp/scaleDown policies and stabilization windows"
         }
       }
     },
@@ -344,6 +370,11 @@
     "affinity": {
       "type": "object",
       "description": "Affinity rules"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "Pod topology spread constraints (preferred over podAntiAffinity since k8s 1.19+). String fields are processed through `tpl`."
     },
     "env": {
       "type": "object",
@@ -496,12 +527,21 @@
                 "targetCPUUtilizationPercentage": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 100
+                  "maximum": 1000
                 },
                 "targetMemoryUtilizationPercentage": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 100
+                  "maximum": 1000
+                },
+                "metrics": {
+                  "type": "array",
+                  "items": { "type": "object" },
+                  "description": "Extra raw HPA v2 metric specs for the worker HPA"
+                },
+                "behavior": {
+                  "type": "object",
+                  "description": "HPA v2 behavior block for the worker HPA"
                 }
               }
             },
@@ -513,6 +553,11 @@
             },
             "affinity": {
               "type": "object"
+            },
+            "topologySpreadConstraints": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "Worker pod topology spread constraints"
             },
             "podAnnotations": {
               "type": "object"
@@ -555,6 +600,11 @@
             },
             "affinity": {
               "type": "object"
+            },
+            "topologySpreadConstraints": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "Beat pod topology spread constraints"
             },
             "podAnnotations": {
               "type": "object"
@@ -639,6 +689,11 @@
             },
             "affinity": {
               "type": "object"
+            },
+            "topologySpreadConstraints": {
+              "type": "array",
+              "items": { "type": "object" },
+              "description": "Flower pod topology spread constraints"
             },
             "podAnnotations": {
               "type": "object"

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -236,6 +236,35 @@ livenessProbe: {}
 ##
 readinessProbe: {}
 
+## Startup probe configuration. Use this for slow-starting applications
+## (e.g. JVM warm-up, Next.js initial build, Rails eager load) so that
+## the kubelet does not start running the liveness probe — or the
+## `failureThreshold` countdown — until the app has reported ready at
+## least once. Without it, a slow boot can cause CrashLoopBackOff under
+## an aggressive liveness probe, or trigger HPA cascades when the
+## boot CPU burst is mistaken for steady-state load.
+##
+## Effective max boot time = periodSeconds * failureThreshold.
+##
+## @param startupProbe Startup probe configuration (empty `{}` disables the probe)
+## @param startupProbe.path HTTP path for the startup probe
+## @param startupProbe.port Port for the startup probe
+## @param startupProbe.httpHeaders Optional HTTP headers for the startup probe
+## @param startupProbe.initialDelaySeconds Seconds before the first probe
+## @param startupProbe.periodSeconds Seconds between probes
+## @param startupProbe.timeoutSeconds Per-probe timeout in seconds
+## @param startupProbe.failureThreshold Consecutive failures before the container is restarted
+## @param startupProbe.successThreshold Consecutive successes before the probe is considered started
+## Example:
+## startupProbe:
+##   path: /healthz
+##   port: 8080
+##   periodSeconds: 10
+##   failureThreshold: 30   # allow up to 5 minutes to boot
+##   timeoutSeconds: 3
+##
+startupProbe: {}
+
 ## @section Resource parameters
 ##
 
@@ -270,8 +299,42 @@ resources:
 ## @param autoscaling.enabled Enable Horizontal Pod Autoscaler
 ## @param autoscaling.minReplicas Minimum number of replicas
 ## @param autoscaling.maxReplicas Maximum number of replicas
-## @param autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage
-## @param autoscaling.targetMemoryUtilizationPercentage Target memory utilization percentage
+## @param autoscaling.targetCPUUtilizationPercentage Target average CPU utilization as a percentage of the container's CPU request. Values > 100 are valid and useful when the request is intentionally small (e.g. you want to allow short bursts above the request before scaling out).
+## @param autoscaling.targetMemoryUtilizationPercentage Target average memory utilization as a percentage of the container's memory request
+## @param autoscaling.metrics Extra raw HPA v2 metric entries appended to the generated `metrics:` list. Use for absolute (`averageValue`) targets, Pods/Object/External metrics. Each entry is a full metric spec.
+## @param autoscaling.behavior HPA v2 `behavior` block controlling scaleUp/scaleDown policies and stabilization windows. Strongly recommended for apps with bursty boot-time CPU (e.g. JVM, Next.js) so that boot bursts do not cascade into runaway scale-up.
+## Example:
+## autoscaling:
+##   enabled: true
+##   minReplicas: 3
+##   maxReplicas: 20
+##   targetCPUUtilizationPercentage: 80
+##   targetMemoryUtilizationPercentage: 80
+##   metrics:
+##     - type: Pods
+##       pods:
+##         metric:
+##           name: http_requests_per_second
+##         target:
+##           type: AverageValue
+##           averageValue: "100"
+##   behavior:
+##     scaleUp:
+##       stabilizationWindowSeconds: 60
+##       policies:
+##         - type: Percent
+##           value: 50
+##           periodSeconds: 60
+##         - type: Pods
+##           value: 2
+##           periodSeconds: 60
+##       selectPolicy: Max
+##     scaleDown:
+##       stabilizationWindowSeconds: 300
+##       policies:
+##         - type: Percent
+##           value: 10
+##           periodSeconds: 60
 ##
 autoscaling:
   enabled: false
@@ -279,6 +342,8 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
+  metrics: []
+  behavior: {}
 
 ## @section Pod Disruption Budget parameters
 ##
@@ -375,6 +440,26 @@ tolerations: []
 ##
 affinity: {}
 
+## @param topologySpreadConstraints Pod topology spread constraints (preferred over `podAntiAffinity` since k8s 1.19+). Use to spread pods evenly across nodes, zones, or other failure domains. Values are processed through `tpl` so you can reference `{{ .Release.Name }}` etc inside string fields.
+## Example:
+## topologySpreadConstraints:
+##   - maxSkew: 1
+##     topologyKey: kubernetes.io/hostname
+##     whenUnsatisfiable: ScheduleAnyway
+##     labelSelector:
+##       matchLabels:
+##         app.kubernetes.io/name: app
+##         app.kubernetes.io/instance: "{{ .Release.Name }}"
+##   - maxSkew: 1
+##     topologyKey: topology.kubernetes.io/zone
+##     whenUnsatisfiable: ScheduleAnyway
+##     labelSelector:
+##       matchLabels:
+##         app.kubernetes.io/name: app
+##         app.kubernetes.io/instance: "{{ .Release.Name }}"
+##
+topologySpreadConstraints: []
+
 ## @section Environment parameters
 ##
 
@@ -466,6 +551,11 @@ initContainer:
 ##     limits:
 ##       cpu: 200m
 ##       memory: 256Mi
+##   startupProbe:
+##     path: /healthz
+##     port: 8080
+##     periodSeconds: 5
+##     failureThreshold: 30
 ##
 sidecarimage: {}
 
@@ -524,9 +614,12 @@ celery:
   ## @param celery.worker.args Worker arguments
   ## @param celery.worker.resources Worker resource limits and requests
   ## @param celery.worker.autoscaling Worker autoscaling configuration
+  ## @param celery.worker.autoscaling.metrics Extra raw HPA v2 metric specs (same shape as `autoscaling.metrics`)
+  ## @param celery.worker.autoscaling.behavior HPA v2 `behavior` block for the worker HPA
   ## @param celery.worker.nodeSelector Worker node selector
   ## @param celery.worker.tolerations Worker tolerations
   ## @param celery.worker.affinity Worker affinity
+  ## @param celery.worker.topologySpreadConstraints Worker topology spread constraints (processed through `tpl`)
   ## @param celery.worker.podAnnotations Worker pod annotations
   ## @param celery.worker.podLabels Worker pod labels
   ##
@@ -542,9 +635,12 @@ celery:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
+      metrics: []
+      behavior: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    topologySpreadConstraints: []
     podAnnotations: {}
     podLabels: {}
 
@@ -556,6 +652,7 @@ celery:
   ## @param celery.beat.nodeSelector Beat node selector
   ## @param celery.beat.tolerations Beat tolerations
   ## @param celery.beat.affinity Beat affinity
+  ## @param celery.beat.topologySpreadConstraints Beat topology spread constraints (processed through `tpl`)
   ## @param celery.beat.podAnnotations Beat pod annotations
   ## @param celery.beat.podLabels Beat pod labels
   ##
@@ -567,6 +664,7 @@ celery:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    topologySpreadConstraints: []
     podAnnotations: {}
     podLabels: {}
 
@@ -581,6 +679,7 @@ celery:
   ## @param celery.flower.nodeSelector Flower node selector
   ## @param celery.flower.tolerations Flower tolerations
   ## @param celery.flower.affinity Flower affinity
+  ## @param celery.flower.topologySpreadConstraints Flower topology spread constraints (processed through `tpl`)
   ## @param celery.flower.podAnnotations Flower pod annotations
   ## @param celery.flower.podLabels Flower pod labels
   ##
@@ -612,5 +711,6 @@ celery:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    topologySpreadConstraints: []
     podAnnotations: {}
     podLabels: {}


### PR DESCRIPTION
## What

Bumps `charts/app` to **1.5.0** and closes the two long-standing items in the chart's `Future Plans` (`startupProbe` and `topologySpreadConstraints`), plus exposes HPA v2 `behavior` and a raw `metrics` list.

These are the four pieces of HPA / scheduling configuration that the chart currently does **not** let users set — and that we hit in production this week diagnosing a HPA cascade on a Next.js UI app where a 30–60 s boot CPU burst was being mistaken by the HPA for steady-state load. Without `behavior.scaleUp.stabilizationWindowSeconds`, the only knob we had was raising `targetCPUUtilizationPercentage` past 100, which the schema also disallowed.

## Changes

### Templates
- `deployment.yaml` — render `startupProbe` for the main container and for `sidecarimage`; render `topologySpreadConstraints` (string fields processed through `tpl` so `{{ .Release.Name }}` resolves inside `labelSelector.matchLabels`).
- `hpa.yaml` — append `.Values.autoscaling.metrics` to the generated `metrics` list; render `.Values.autoscaling.behavior`.
- `celery-worker-hpa.yaml` — same additions for `celery.worker.autoscaling`.
- `celery-{worker,beat,flower}-deployment.yaml` — render `topologySpreadConstraints` (tpl-processed).

### Values + schema
- New keys with `@param` doc comments: `startupProbe`, `sidecarimage.startupProbe`, `autoscaling.{metrics,behavior}`, `topologySpreadConstraints`, `celery.worker.autoscaling.{metrics,behavior}`, `celery.{worker,beat,flower}.topologySpreadConstraints`.
- `values.schema.json` — matching entries.
- Schema `maximum` on `targetCPUUtilizationPercentage` / `targetMemoryUtilizationPercentage` (main + celery worker) raised from `100` to `1000`. Utilization is a percentage of the container's *request*, not of node capacity, and values >100 are valid and common when the request is intentionally small to allow short bursts before scaling out.

### Examples + docs
- New `examples/with-startup-probe.yaml` — slow-booting app pattern.
- New `examples/with-topology-spread.yaml` — node + zone spread using the modern API.
- Updated `examples/with-autoscaling.yaml` to demonstrate `autoscaling.behavior`, `autoscaling.metrics`, and `topologySpreadConstraints` alongside the existing affinity example.
- README parameter tables and `examples/README.md` entries for the new examples.
- `CHANGELOG.md` — new `[1.5.0]` section; removed `startupProbe` and `topologySpreadConstraints` from Future Plans.
- `Chart.yaml` — version bump `1.4.0` → `1.5.0`.

### Alignment with newer Kubernetes standards
- `startupProbe` is GA since 1.20.
- HPA `autoscaling/v2` `behavior` is GA since 1.23.
- `topologySpreadConstraints` stable since 1.19; the Pod Topology Spread scheduler plugin is default-on since 1.25 and is the preferred replacement for `podAntiAffinity` for spread.
- All within the chart's existing `kubeVersion: '>=1.29.0-0'` floor — no constraint change needed.

## Backward compatibility

All additions are opt-in and default to empty (`{}` / `[]`) or zero. Existing values files render byte-identical Kubernetes manifests on 1.5.0 as they did on 1.4.0. No migration required.

## Verification

Ran the equivalent of `make check` locally on Windows (no bash available):
- `helm lint charts/app` — clean.
- `helm template` against every `examples/*.yaml` — clean.
- `helm install --dry-run=client` against every `examples/*.yaml` — passes `values.schema.json` validation (this is when Helm actually enforces the schema).
- Negative test: `targetCPUUtilizationPercentage: 5000` is correctly rejected by the schema (cap is 1000). 
- Positive test: `tpl` in `topologySpreadConstraints` correctly resolves `{{ .Release.Name }}` in `labelSelector.matchLabels`.
- Combined test: enabling celery worker autoscaling with `behavior`, External-metric, and `topologySpreadConstraints` renders the correct `autoscaling/v2` `HorizontalPodAutoscaler` and `Deployment`.

CI will also run `ct lint`, render every example, `kubeconform -strict` against k8s 1.33–1.36, and a real `kind` install on 1.33/1.34/1.35.
