### PR TITLE
app: v1.5.0 follow-ups — example coverage, schema, sidecar probe (1.5.1)

### DIFF
--- a/charts/app/CHANGELOG.md
+++ b/charts/app/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-06-26
+
+### Fixed
+- `sidecarimage.startupProbe` now renders `httpHeaders` (it was silently dropped, despite the README stating the sidecar probe has the same shape as the main container's `startupProbe`).
+- `startupProbe.successThreshold` schema constrained to `1`. Kubernetes only permits `1` for startup probes; any other value was previously accepted by `helm`/CI and rejected only at apply time.
+
+### Changed
+- `examples/with-topology-spread.yaml` and `examples/with-autoscaling.yaml` scope their `topologySpreadConstraints` to the main app's pods via a `app.kubernetes.io/component DoesNotExist` expression, so co-deployed celery pods (which share `name`/`instance`) are not counted in the skew.
+- `examples/celery-workers.yaml` now exercises `celery.worker.autoscaling.metrics`, `celery.worker.autoscaling.behavior`, and `celery.worker.topologySpreadConstraints`, so CI renders and validates those paths.
+
 ## [1.5.0] - 2026-06-24
 
 ### Added

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.5.0"
+version: "1.5.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app/examples/celery-workers.yaml
+++ b/charts/app/examples/celery-workers.yaml
@@ -70,6 +70,36 @@ celery:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 70
       targetMemoryUtilizationPercentage: 80
+      # Extra raw HPA v2 metric specs, appended to the generated metrics
+      # list. Here: scale on Celery queue depth (requires a custom-metrics
+      # adapter exposing the metric).
+      metrics:
+        - type: Pods
+          pods:
+            metric:
+              name: celery_queue_depth
+            target:
+              type: AverageValue
+              averageValue: "30"
+      # HPA v2 behavior: let scale-down breathe so a brief drop in queue
+      # depth does not immediately tear down warm workers.
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
+    # Spread workers across nodes. Scoped to the worker component so the
+    # skew is computed over worker pods only.
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}"
+            app.kubernetes.io/component: celery-worker
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9090"

--- a/charts/app/examples/with-autoscaling.yaml
+++ b/charts/app/examples/with-autoscaling.yaml
@@ -93,6 +93,8 @@ readinessProbe:
 # Topology spread is the modern Kubernetes-native way to spread pods.
 # Prefer this over `podAntiAffinity` for new deployments. labelSelector
 # values are processed through `tpl`, so {{ .Release.Name }} works.
+# The `DoesNotExist` expression scopes the spread to the main app's pods
+# so any celery replicas (which share name/instance) are not counted.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname
@@ -101,6 +103,9 @@ topologySpreadConstraints:
       matchLabels:
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: DoesNotExist
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
@@ -108,6 +113,9 @@ topologySpreadConstraints:
       matchLabels:
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: DoesNotExist
 
 # Node affinity to prefer specific node types (kept for backward-compat).
 # topologySpreadConstraints above handles the "spread evenly" concern.

--- a/charts/app/examples/with-topology-spread.yaml
+++ b/charts/app/examples/with-topology-spread.yaml
@@ -47,6 +47,12 @@ resources:
 # The labelSelector here uses the chart's standard selector labels.
 # String fields are processed through `tpl`, so `{{ .Release.Name }}`
 # resolves correctly.
+#
+# NOTE: celery pods (worker/beat/flower) share `app.kubernetes.io/name`
+# and `app.kubernetes.io/instance` with the main deployment and only add
+# `app.kubernetes.io/component`. The `DoesNotExist` expression below
+# scopes the spread to the main app's own pods so celery replicas are not
+# counted in the skew when celery is enabled in the same release.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname
@@ -55,6 +61,9 @@ topologySpreadConstraints:
       matchLabels:
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: DoesNotExist
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
@@ -62,3 +71,6 @@ topologySpreadConstraints:
       matchLabels:
         app.kubernetes.io/name: app
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: DoesNotExist

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -166,6 +166,10 @@ spec:
             httpGet:
               path: {{ .Values.sidecarimage.startupProbe.path }}
               port: {{ .Values.sidecarimage.startupProbe.port }}
+              {{- with .Values.sidecarimage.startupProbe.httpHeaders }}
+              httpHeaders:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
             {{- with .Values.sidecarimage.startupProbe.initialDelaySeconds }}
             initialDelaySeconds: {{ . }}
             {{- end }}

--- a/charts/app/values.schema.json
+++ b/charts/app/values.schema.json
@@ -249,7 +249,7 @@
         "periodSeconds": { "type": "integer", "minimum": 1 },
         "timeoutSeconds": { "type": "integer", "minimum": 1 },
         "failureThreshold": { "type": "integer", "minimum": 1 },
-        "successThreshold": { "type": "integer", "minimum": 1 }
+        "successThreshold": { "type": "integer", "const": 1, "description": "Must be 1 for a startup probe; Kubernetes rejects any other value at apply time." }
       }
     },
     "autoscaling": {


### PR DESCRIPTION
## What

Follow-up fixes for the four issues opened during the review of #12. All are small, opt-in, and backward-compatible. Bumps `charts/app` to **1.5.1**.

Closes #13
Closes #14
Closes #15
Closes #16

## Changes

- **#13 — celery example coverage.** `examples/celery-workers.yaml` now exercises `celery.worker.autoscaling.metrics` (a queue-depth Pods metric), `celery.worker.autoscaling.behavior` (a scaleDown stabilization window), and `celery.worker.topologySpreadConstraints`. These template branches shipped in 1.5.0 with no example, so CI never rendered them; now it does.
- **#14 — topology-spread example selector scope.** `examples/with-topology-spread.yaml` and `examples/with-autoscaling.yaml` scope the **main** deployment's `topologySpreadConstraints` to the app's own pods via `matchExpressions: [{key: app.kubernetes.io/component, operator: DoesNotExist}]`. Celery pods share `name`/`instance` and only add `component`, so without this they were counted in the main app's skew when co-deployed.
- **#15 — `startupProbe.successThreshold` schema.** Constrained to `const: 1`. Kubernetes only permits `1` for startup probes; previously `helm`/CI accepted any value and it failed only at apply time. Now rejected at render.
- **#16 — sidecar `startupProbe` `httpHeaders`.** The sidecar probe now renders `httpHeaders` to match the main container and the README's "same shape as the main container's `startupProbe`" claim (it was previously silently dropped).
- **Version + changelog.** `Chart.yaml` `1.5.0` → `1.5.1`; new `[1.5.1]` CHANGELOG section.

No README parameter-table changes: no new params were added, only constraints/behavior on existing ones.

## Verification

Run locally with Helm:
- `helm lint charts/app` — clean.
- `helm template` against every `examples/*.yaml` — all render.
- Negative test: `startupProbe.successThreshold=2` is now rejected by the schema (`value must be 1`); `1` passes.
- Rendered and confirmed: sidecar `startupProbe.httpHeaders` emits; main topology constraints carry the `DoesNotExist` expression; celery worker HPA renders `behavior` + appended `metrics`; celery worker Deployment renders `topologySpreadConstraints`.

CI will additionally run `ct lint`, kubeconform, and a real kind install.