### PR TITLE
cron: add chart for scheduled jobs (0.1.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,17 @@ Operational guide for AI agents working in this repository. Conventions below ap
 
 ## What this repo is
 
-A small collection of personal Helm charts. Today the only chart is `charts/app` — a flexible application chart with optional Celery worker/beat/flower components, hooks, init containers, sidecars, HPA, PDB, and ingress.
+A small collection of personal Helm charts:
+
+- `charts/app` — a flexible application chart with optional Celery worker/beat/flower components, hooks, init containers, sidecars, HPA, PDB, and ingress.
+- `charts/cron` — scheduled jobs. One release defines many CronJobs from a `cronjobs` map: top-level keys are shared defaults, each entry deep-merges its own overrides on top. Sidecars render as native sidecars (init containers with `restartPolicy: Always`), the only pattern that lets a Job with a helper container complete.
 
 ## Layout
 
 ```
 charts/                          Helm charts (each is self-contained)
   app/
+  cron/
     Chart.yaml                   Version, kubeVersion, maintainers
     values.yaml                  Documented with @param doc comments
     values.schema.json           Must stay in sync with values.yaml
@@ -88,8 +92,9 @@ Tool versions are pinned both in `.github/workflows/ci.yaml` (env vars at the to
 
 ## Where to learn the domain
 
-- Chart-specific docs: [`charts/app/README.md`](charts/app/README.md)
-- Per-chart changelog: [`charts/app/CHANGELOG.md`](charts/app/CHANGELOG.md)
+- Chart-specific docs: [`charts/app/README.md`](charts/app/README.md), [`charts/cron/README.md`](charts/cron/README.md)
+- Per-chart changelog: [`charts/app/CHANGELOG.md`](charts/app/CHANGELOG.md), [`charts/cron/CHANGELOG.md`](charts/cron/CHANGELOG.md)
+- CronJob concepts: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 - Helm chart best practices: https://helm.sh/docs/chart_best_practices/
 - chart-testing: https://github.com/helm/chart-testing
 - kubeconform: https://github.com/yannh/kubeconform

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ Personal collection of Helm charts. Each chart lives under `charts/` and ships w
 | Chart | Description | Docs |
 |-------|-------------|------|
 | [`app`](charts/app) | Flexible application chart with optional Celery (worker/beat/flower), hooks, init containers, sidecars, HPA, PDB, and ingress | [README](charts/app/README.md) · [CHANGELOG](charts/app/CHANGELOG.md) · [Examples](charts/app/examples) |
+| [`cron`](charts/cron) | Scheduled jobs — many CronJobs per release sharing a common pod spec, with per-job overrides, native sidecars, and full Job control | [README](charts/cron/README.md) · [CHANGELOG](charts/cron/CHANGELOG.md) · [Examples](charts/cron/examples) |
 
 ## Quick start
 
 ```sh
 helm install my-app ./charts/app -f my-values.yaml
+helm install my-crons ./charts/cron -f my-cron-values.yaml
 ```
 
-See the chart's [README](charts/app/README.md) for parameters and the [`examples/`](charts/app/examples) directory for ready-to-use values files covering basic web apps, ingress + TLS, Celery, init containers, hooks, autoscaling, and sidecars.
+See each chart's README for parameters and its `examples/` directory for ready-to-use values files: [`app`](charts/app/README.md) covers basic web apps, ingress + TLS, Celery, init containers, hooks, autoscaling, and sidecars ([examples](charts/app/examples)); [`cron`](charts/cron/README.md) covers single and multi-cron releases, Indexed parallel jobs, pod failure policies, and security hardening ([examples](charts/cron/examples)).
 
 ## Repository layout
 
@@ -65,7 +67,7 @@ See [`AGENTS.md`](AGENTS.md) for the full conventions guide.
 
 ## Kubernetes compatibility
 
-The `app` chart currently targets Kubernetes 1.29 and newer. CI validates manifest rendering up to the latest stable Kubernetes release and installs on the most recent versions that `kind` ships node images for. Each chart's `CHANGELOG.md` records the supported floor per release.
+The `app` and `cron` charts currently target Kubernetes 1.29 and newer. CI validates manifest rendering up to the latest stable Kubernetes release and installs on the most recent versions that `kind` ships node images for. Each chart's `CHANGELOG.md` records the supported floor per release.
 
 ## License
 

--- a/charts/cron/CHANGELOG.md
+++ b/charts/cron/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this Helm chart will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-17
+
+### Added
+- Initial release of the `cron` chart.
+- Define many Kubernetes CronJobs from a single release via a `cronjobs` map of `<name>` -> overrides. Top-level keys act as shared defaults; each entry deep-merges its overrides on top (per-job value wins; maps merge key-by-key, lists are replaced). Each entry renders one CronJob named `<release-fullname>-<name>`.
+- Full CronJob scheduling control: `schedule`, `timeZone`, `concurrencyPolicy`, `suspend`, `startingDeadlineSeconds`, and successful/failed job history limits.
+- Full Job control under `job`: `restartPolicy`, `backoffLimit`, `ttlSecondsAfterFinished`, `activeDeadlineSeconds`, `parallelism`, `completions`, `completionMode`, `backoffLimitPerIndex`, `maxFailedIndexes`, `podReplacementPolicy`, and `podFailurePolicy`.
+- Full pod spec control: image, command/args, `env`/`secretEnv`/`envFrom`, resources, security contexts, volumes/mounts, lifecycle, node selector, tolerations, affinity, topology spread, priority class, runtime class, and termination grace period.
+- One-shot init container and **native sidecars** (rendered as init containers with `restartPolicy: Always`) so long-running helpers don't block Job completion.
+- Release-scoped helper resources: ServiceAccount, optional RBAC Role/RoleBinding, ConfigMaps, External Secrets, PersistentVolumeClaim, and NetworkPolicy.
+- `values.schema.json` (JSON Schema Draft 7) validated at lint/template/install time. The schema is closed at the top level, so a typo'd key fails rendering rather than being silently ignored.
+- Examples: single cron, multi-cron with shared defaults, an Indexed parallel job with a native sidecar, a pod failure policy, and a security-hardened configuration. A Helm test confirms the configured image is pullable and runnable.
+- Targets Kubernetes 1.29+.
+
+### Notes
+- Cronjob map keys are normalized to DNS-1123 labels (e.g. `Nightly_Cleanup` -> `nightly-cleanup`) for resource names, container names, and label values.
+- Each cron's resources carry `app.kubernetes.io/component: <name>` alongside the standard labels, so a single cron's jobs and pods can be selected independently of the rest of the release.
+- Sidecars require an explicit `image.repository` and `image.tag`, and accept `commands` (matching the main container) as well as `command`.
+- Every entry under `cronjobs` must resolve to a non-empty `schedule` — set it per-job or as a shared default. Rendering fails with a named error otherwise.

--- a/charts/cron/Chart.yaml
+++ b/charts/cron/Chart.yaml
@@ -1,0 +1,51 @@
+apiVersion: v2
+name: cron
+description: A Helm chart for running scheduled jobs on Kubernetes. One release defines many CronJobs that share a common pod spec, with per-job overrides.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "0.1.0"
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+# Kubernetes version constraint. Matches charts/app and what CI exercises (kind install on
+# 1.33-1.35, manifest validation up to 1.36). 1.29 is the floor because sidecars render as
+# native sidecars (init containers with restartPolicy: Always), stable in 1.29.
+kubeVersion: ">=1.29.0-0"
+
+# A list of keywords about this project
+keywords:
+  - kubernetes
+  - cron
+  - cronjob
+  - scheduled
+  - batch
+  - job
+
+# The URL of this projects home page
+home: https://github.com/etowett/helm-charts
+
+# A list of URLs to source code for this project
+sources:
+  - https://github.com/etowett/helm-charts
+
+# A list of the chart maintainers
+maintainers:
+  - name: etowett
+    email: ektowett@gmail.com
+    url: https://github.com/etowett

--- a/charts/cron/README.md
+++ b/charts/cron/README.md
@@ -1,0 +1,406 @@
+# Cron Helm Chart
+
+A Helm chart for running scheduled jobs in Kubernetes. One release defines **many CronJobs** that share a common pod spec, with per-job overrides and full control over scheduling, concurrency, retries, history, and parallelism.
+
+## Features
+
+- Many CronJobs per release from a single `cronjobs` map — no installing the chart once per cron
+- Shared defaults with per-job overrides (deep-merged: maps merge key-by-key, lists replace)
+- Full CronJob control — `schedule`, `timeZone`, `concurrencyPolicy`, `suspend`, `startingDeadlineSeconds`, history limits
+- Full Job control — `backoffLimit`, `ttlSecondsAfterFinished`, `activeDeadlineSeconds`, `parallelism`, `completions`, `completionMode`, per-index retries, `podReplacementPolicy`, `podFailurePolicy`
+- Full pod spec — env / secret env / envFrom, resources, security contexts, volumes, lifecycle, scheduling (affinity, tolerations, topology spread, priority/runtime class)
+- Native sidecars (init containers with `restartPolicy: Always`) so helpers don't block Job completion
+- Init containers for migrations and pre-run setup
+- Release-scoped helpers — ServiceAccount, optional RBAC, ConfigMaps, External Secrets, PVC, NetworkPolicy
+- Schema-validated `values.yaml` (`values.schema.json`)
+
+## Prerequisites
+
+- Kubernetes 1.29+
+- Helm 3.8+
+
+Optional:
+
+- **External Secrets Operator** — required for `externalSecrets`
+
+## Installing the Chart
+
+To install the chart with the release name `my-crons`:
+
+```bash
+helm install my-crons ./charts/cron -f my-values.yaml
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall my-crons
+```
+
+## How it works
+
+Every top-level key in `values.yaml` is a **shared default**. Each entry under `cronjobs` is a named CronJob (`<release-fullname>-<name>`) that may **override any shared key**. Overrides are deep-merged over the defaults: the per-job value wins, maps such as `env` merge key-by-key, and lists such as `args` or `sidecars` are replaced wholesale.
+
+```yaml
+image:
+  repository: myrepo/worker
+  tag: v1.2.3
+env:
+  LOG_LEVEL: info          # shared by every cron
+
+cronjobs:
+  nightly-cleanup:
+    schedule: "0 2 * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/cleanup"]
+  hourly-sync:
+    schedule: "0 * * * *"
+    args: ["-c", "bin/sync"]
+    concurrencyPolicy: Replace
+    env:
+      BATCH_SIZE: "1000"   # merged on top of the shared env
+    resources:
+      limits: { cpu: 500m, memory: 256Mi }
+```
+
+This renders two CronJobs (`my-crons-nightly-cleanup`, `my-crons-hourly-sync`) sharing one image and base env, each with its own schedule and overrides.
+
+Cronjob map keys are normalized to DNS-1123 labels (e.g. `Nightly_Cleanup` becomes `nightly-cleanup`) for resource names, container names, and label values. Each cron's resources carry `app.kubernetes.io/component: <name>`, so a single cron's jobs and pods can be selected on their own.
+
+## Configuration
+
+### Image Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Container image repository shared by every cronjob | `busybox` |
+| `image.pullPolicy` | Image pull policy (`Always`, `IfNotPresent`, `Never`) | `IfNotPresent` |
+| `image.tag` | Image tag (overrides the chart appVersion if set) | `"1.36"` |
+| `imagePullSecrets` | Kubernetes secret names for pulling private images | `[]` |
+
+### Global Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full name of resources | `""` |
+
+### Service Account Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Specifies whether a service account should be created | `true` |
+| `serviceAccount.automount` | Automatically mount the ServiceAccount's API credentials | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account (e.g. IRSA / Workload Identity) | `{}` |
+| `serviceAccount.name` | Name of the service account (generated from the fullname template if empty) | `""` |
+| `serviceAccountName` | Use a specific ServiceAccount name without creating one (overridable per-job) | `""` |
+
+### Pod Metadata Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `annotations` | Annotations applied to every CronJob resource's metadata | `{}` |
+| `podAnnotations` | Annotations added to every job pod | `{}` |
+| `podLabels` | Labels added to every job pod | `{}` |
+
+### Security Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podSecurityContext` | Pod-level security context | `{}` |
+| `securityContext` | Container-level security context for the main job container | `{}` |
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+```
+
+### Container Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `commands` | Override the container entrypoint | `[]` |
+| `args` | Override the container arguments | `[]` |
+| `workingDir` | Working directory for the main container | `""` |
+| `resources` | Resource limits and requests for the main job container | `{}` |
+| `lifecycle` | Lifecycle hooks for the main container | `{}` |
+| `env` | Environment variables as key-value pairs | `{}` |
+| `secretEnv` | Environment variables sourced from existing secrets | `{}` |
+| `envFrom` | Mount entire ConfigMaps or Secrets as environment variables | `[]` |
+
+```yaml
+env:
+  LOG_LEVEL: "info"
+secretEnv:
+  DATABASE_PASSWORD:
+    name: db-secret
+    key: password
+envFrom:
+  - secretRef:
+      name: cron-secrets
+```
+
+### Storage Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `volumes` | Additional volumes for the pod | `[]` |
+| `volumeMounts` | Additional volume mounts for the main container | `[]` |
+| `pvc.enabled` | Create a PersistentVolumeClaim | `false` |
+| `pvc.name` | PVC name (defaults to the fullname template) | `""` |
+| `pvc.annotations` | Annotations to add to the PVC | `{}` |
+| `pvc.accessModes` | Access modes for the PVC | `["ReadWriteOnce"]` |
+| `pvc.size` | Storage size to request | `10Gi` |
+| `pvc.storageClassName` | Storage class (uses the cluster default if empty) | `""` |
+| `pvc.volumeMode` | Volume mode (`Filesystem` or `Block`) | `Filesystem` |
+| `pvc.selector` | Label selector to bind a specific volume | `{}` |
+
+### Scheduling Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `tolerations` | Tolerations for pod assignment | `[]` |
+| `affinity` | Affinity rules for pod assignment | `{}` |
+| `topologySpreadConstraints` | Topology spread constraints for pod assignment | `[]` |
+| `priorityClassName` | Pod priority class name | `""` |
+| `runtimeClassName` | Runtime class name (gVisor, Kata, etc.) | `""` |
+| `terminationGracePeriodSeconds` | Grace period before a job pod is force-killed | `30` |
+
+### Init Container Parameters
+
+A one-shot init container (e.g. migrations) that must complete before the main container starts. It reuses the cron's image and the shared `env`/`secretEnv`.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `initContainer.enabled` | Enable the one-shot init container | `false` |
+| `initContainer.name` | Init container name | `init` |
+| `initContainer.commands` | Override the init container entrypoint | `[]` |
+| `initContainer.args` | Override the init container arguments | `[]` |
+| `initContainer.resources` | Resource limits and requests for the init container | `{}` |
+| `initContainer.volumeMounts` | Volume mounts for the init container | `[]` |
+
+```yaml
+initContainer:
+  enabled: true
+  name: migrate
+  commands: ["/bin/sh"]
+  args: ["-c", "bin/migrate"]
+```
+
+### Sidecar Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `sidecars` | Native sidecar containers (requires Kubernetes 1.29+) | `[]` |
+
+Sidecars render as **native sidecars** — init containers with `restartPolicy: Always`. This is the correct pattern for Jobs: the sidecar runs alongside the main container and is terminated automatically once the main container exits, so the Job can complete. A plain sidecar would keep the Job running forever.
+
+Each entry requires an explicit `image.repository` and `image.tag`, and accepts `commands` (matching the main container) as well as `command`. Probes (`httpGet` / `tcpSocket` / `exec` / `grpc`) are supported.
+
+```yaml
+sidecars:
+  - name: cloud-sql-proxy
+    image:
+      repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+      tag: "2.11.0"
+    args: ["--port=5432", "my-project:us-central1:my-instance"]
+    resources:
+      limits: { cpu: 200m, memory: 128Mi }
+    startupProbe:
+      tcpSocket: { port: 5432 }
+      periodSeconds: 5
+      failureThreshold: 12
+```
+
+### CronJob Scheduling Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `schedule` | Default cron schedule used when a cronjob omits its own | `""` |
+| `timeZone` | IANA time zone for the schedule, e.g. `America/New_York` | `""` |
+| `concurrencyPolicy` | How to treat concurrent runs (`Allow`, `Forbid`, `Replace`) | `Forbid` |
+| `suspend` | Suspend the schedule (no new jobs are created while true) | `false` |
+| `startingDeadlineSeconds` | Deadline for starting a job that missed its scheduled time | `null` |
+| `successfulJobsHistoryLimit` | How many completed jobs to retain | `3` |
+| `failedJobsHistoryLimit` | How many failed jobs to retain | `1` |
+
+Every entry under `cronjobs` must resolve to a non-empty `schedule`, set either per-job or as a shared default. Rendering fails with a named error if one does not.
+
+### Job Parameters
+
+Set under `job` (shared) or `cronjobs.<name>.job` (per-job).
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `job.restartPolicy` | Restart policy for job pods (`OnFailure` or `Never`) | `OnFailure` |
+| `job.backoffLimit` | Number of retries before the job is marked failed | `6` |
+| `job.ttlSecondsAfterFinished` | Auto-clean finished jobs this many seconds after completion | `3600` |
+| `job.activeDeadlineSeconds` | Hard wall-clock limit for a single job run, in seconds | `null` |
+| `job.parallelism` | Number of pods running in parallel | `null` |
+| `job.completions` | Number of successful completions required | `null` |
+| `job.completionMode` | `NonIndexed` or `Indexed` | `NonIndexed` |
+| `job.backoffLimitPerIndex` | Per-index retry limit for Indexed jobs | `null` |
+| `job.maxFailedIndexes` | Maximum failed indexes before an Indexed job fails | `null` |
+| `job.podReplacementPolicy` | When to create replacement pods (`Failed`, `TerminatingOrFailed`) | `null` |
+| `job.podFailurePolicy` | Fine-grained handling of pod failures | `{}` |
+
+#### Pod failure policy
+
+React to *why* a pod failed instead of blindly retrying:
+
+```yaml
+job:
+  podFailurePolicy:
+    rules:
+      - action: FailJob          # non-retriable exit code → fail immediately
+        onExitCodes:
+          operator: In
+          values: [42]
+      - action: Ignore           # node drain → don't count against backoffLimit
+        onPodConditions:
+          - type: DisruptionTarget
+            status: "True"
+```
+
+### CronJobs
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `cronjobs` | Map of `<name>` → per-cronjob overrides (each must resolve to a `schedule`) | `{}` |
+
+### Helper Resource Parameters
+
+Release-scoped resources, created once per release rather than per cronjob.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `configMaps` | ConfigMaps to create | `[]` |
+| `externalSecrets` | External Secrets to create (requires the External Secrets Operator) | `[]` |
+| `networkPolicy.enabled` | Create a NetworkPolicy for the cronjob pods | `false` |
+| `networkPolicy.policyTypes` | Policy types to enforce | `["Egress"]` |
+| `networkPolicy.ingress` | Ingress rules | `[]` |
+| `networkPolicy.egress` | Egress rules | `[]` |
+| `rbac.enabled` | Create a Role and RoleBinding for the ServiceAccount | `false` |
+| `rbac.rules` | Role rules | `[]` |
+
+```yaml
+rbac:
+  enabled: true
+  rules:
+    - apiGroups: ["batch"]
+      resources: ["jobs"]
+      verbs: ["get", "list", "watch"]
+
+externalSecrets:
+  - name: cron-db
+    refreshInterval: 1h
+    secretStoreRefName: gcp-secret-store
+    targetName: cron-db
+    dataKey: prod/cron/db
+
+networkPolicy:
+  enabled: true
+  policyTypes: ["Egress"]
+  egress:
+    - ports:
+        - { protocol: TCP, port: 443 }
+```
+
+## Examples
+
+Ready-to-use values files live in [`examples/`](examples/). See the [examples README](examples/README.md) for the full list.
+
+### A single scheduled job
+
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/single-cron.yaml
+```
+
+```yaml
+image:
+  repository: myrepo/worker
+  tag: "v1.2.3"
+
+cronjobs:
+  nightly-cleanup:
+    schedule: "0 2 * * *"
+    timeZone: "America/New_York"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/cleanup --older-than=30d"]
+    job:
+      backoffLimit: 3
+      activeDeadlineSeconds: 1800
+```
+
+### Several crons sharing one image and config
+
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/multi-cron-shared.yaml
+```
+
+### A parallel, Indexed job
+
+Shard a batch across N workers. Each pod gets a unique `JOB_COMPLETION_INDEX`, and the job completes when every index succeeds.
+
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/indexed-parallel-job.yaml
+```
+
+```yaml
+cronjobs:
+  shard-processor:
+    schedule: "*/30 * * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/process --shard=$JOB_COMPLETION_INDEX --of=4"]
+    job:
+      completionMode: Indexed
+      completions: 4
+      parallelism: 4
+      backoffLimitPerIndex: 2
+```
+
+## Operating cronjobs
+
+```bash
+# List the cronjobs this release created
+kubectl get cronjobs -l app.kubernetes.io/instance=my-crons
+
+# Trigger a run now, without waiting for the schedule
+kubectl create job my-run --from=cronjob/my-crons-nightly-cleanup
+
+# Inspect runs and logs for one cron
+kubectl get jobs -l app.kubernetes.io/instance=my-crons,app.kubernetes.io/component=nightly-cleanup
+kubectl logs -l app.kubernetes.io/instance=my-crons --tail=100 -f
+
+# Pause / resume a schedule (or set suspend: true in values)
+kubectl patch cronjob my-crons-hourly-sync -p '{"spec":{"suspend":true}}'
+```
+
+## Troubleshooting
+
+**A cronjob never runs.** Check that it is not suspended and that the schedule is what you expect: `kubectl describe cronjob <name>`. If `startingDeadlineSeconds` is set and the controller was down longer than that, the run is skipped rather than backfilled.
+
+**Jobs pile up or overlap.** The default `concurrencyPolicy: Forbid` skips a run whose predecessor is still going. Use `Replace` to kill the old run, or raise `job.activeDeadlineSeconds` if runs legitimately take longer than the interval.
+
+**A job never completes and stays Running.** If a helper container keeps running after the main container exits, it must be under `sidecars` (native sidecars are terminated automatically), not a plain container.
+
+**Finished jobs accumulate.** Lower `job.ttlSecondsAfterFinished`, or the `successfulJobsHistoryLimit` / `failedJobsHistoryLimit`.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
+## License
+
+[MIT](../../LICENSE) © Eutychus Towett.

--- a/charts/cron/examples/README.md
+++ b/charts/cron/examples/README.md
@@ -1,0 +1,76 @@
+# Helm Chart Examples
+
+This directory contains example configuration files for common scheduling scenarios using this Helm chart. Each is rendered and validated by CI.
+
+## Available Examples
+
+### 1. Single Cron
+**File:** `single-cron.yaml`
+
+The simplest useful configuration — one CronJob running a nightly cleanup:
+- A fixed `timeZone` so the schedule doesn't drift with the cluster's clock
+- Resource limits and requests
+- A retry `backoffLimit` and an `activeDeadlineSeconds` wall-clock limit
+
+**Usage:**
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/single-cron.yaml
+```
+
+### 2. Multiple Crons with Shared Defaults
+**File:** `multi-cron-shared.yaml`
+
+Three CronJobs (cleanup, sync, weekly report) in one release — the core shared-defaults pattern:
+- Shared image, `env`, security contexts, resources, and Job defaults
+- Per-job overrides: `concurrencyPolicy: Replace`, an extra merged `env` var, `secretEnv`, a per-job `backoffLimit`, and per-job resources
+
+**Usage:**
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/multi-cron-shared.yaml
+```
+
+### 3. Indexed Parallel Job
+**File:** `indexed-parallel-job.yaml`
+
+A batch sharded across parallel workers:
+- `completionMode: Indexed` with `completions`/`parallelism: 4` — each pod gets a unique `JOB_COMPLETION_INDEX`
+- `backoffLimitPerIndex`, `maxFailedIndexes`, and `podReplacementPolicy`
+- A native sidecar (Cloud SQL proxy) that is torn down automatically so the job can complete
+
+**Usage:**
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/indexed-parallel-job.yaml
+```
+
+### 4. Pod Failure Policy
+**File:** `pod-failure-policy.yaml`
+
+Retries that depend on *why* a pod failed:
+- Fail fast on a non-retriable application exit code
+- Ignore node-drain disruptions so they don't burn the `backoffLimit`
+
+**Usage:**
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/pod-failure-policy.yaml
+```
+
+### 5. Security Hardened
+**File:** `security-hardened.yaml`
+
+A configuration for workloads under strict security requirements:
+- Restricted Pod Security Standards (`runAsUser: 65534`, read-only root filesystem, dropped capabilities)
+- `serviceAccount.automount: false`
+- A default-deny NetworkPolicy allowing only DNS and HTTPS egress
+- External Secrets instead of inline secrets, and minimal RBAC
+
+**Usage:**
+```bash
+helm install my-crons ./charts/cron -f ./charts/cron/examples/security-hardened.yaml
+```
+
+## Notes
+
+- Every entry under `cronjobs` must resolve to a non-empty `schedule` — set it on the job or as a shared top-level default.
+- Top-level keys are shared defaults. A per-job override deep-merges over them: maps (like `env`) merge key-by-key, lists (like `args` or `sidecars`) are replaced wholesale.
+- `sidecars` render as **native sidecars** (init containers with `restartPolicy: Always`, Kubernetes 1.29+) so a long-running helper doesn't keep the Job from completing.
+- These files use placeholder images and secret names — replace them with real values for your deployment.

--- a/charts/cron/examples/indexed-parallel-job.yaml
+++ b/charts/cron/examples/indexed-parallel-job.yaml
@@ -1,0 +1,45 @@
+# A parallel, Indexed CronJob: shard a batch across N workers. Each pod gets a unique
+# JOB_COMPLETION_INDEX (0..completions-1) and the job is complete when every index succeeds.
+# Includes a native sidecar (Cloud SQL proxy) that runs alongside each worker and is torn down
+# automatically so the job can complete.
+image:
+  repository: myrepo/batch-processor
+  tag: "v2.0.0"
+  pullPolicy: IfNotPresent
+
+env:
+  LOG_LEVEL: "info"
+
+cronjobs:
+  shard-processor:
+    schedule: "*/30 * * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/process --shard=$JOB_COMPLETION_INDEX --of=4"]
+    job:
+      completionMode: Indexed
+      completions: 4
+      parallelism: 4
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 1
+      podReplacementPolicy: Failed
+    sidecars:
+      - name: cloud-sql-proxy
+        image:
+          repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+          tag: "2.11.0"
+          pullPolicy: IfNotPresent
+        args: ["--port=5432", "my-project:us-central1:my-instance"]
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        startupProbe:
+          tcpSocket:
+            port: 5432
+          periodSeconds: 5
+          failureThreshold: 12

--- a/charts/cron/examples/multi-cron-shared.yaml
+++ b/charts/cron/examples/multi-cron-shared.yaml
@@ -1,0 +1,72 @@
+# Several related cronjobs in one release, sharing a common image, env, security context, and
+# resources. Each entry overrides only what it needs. Demonstrates the shared-defaults pattern
+# and a per-job concurrencyPolicy / secretEnv override.
+image:
+  repository: myrepo/worker
+  tag: "v1.2.3"
+  pullPolicy: IfNotPresent
+
+# Shared across every cronjob below.
+env:
+  LOG_LEVEL: "info"
+  APP_ENV: "production"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Shared Job defaults; individual jobs override pieces of this.
+job:
+  backoffLimit: 4
+  ttlSecondsAfterFinished: 3600
+
+cronjobs:
+  nightly-cleanup:
+    schedule: "0 2 * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/cleanup"]
+
+  hourly-sync:
+    schedule: "0 * * * *"
+    concurrencyPolicy: Replace
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/sync"]
+    # Merge an extra env var on top of the shared env map.
+    env:
+      BATCH_SIZE: "1000"
+    secretEnv:
+      DATABASE_PASSWORD:
+        name: db-secret
+        key: password
+    job:
+      backoffLimit: 2
+
+  weekly-report:
+    schedule: "0 6 * * 1"
+    timeZone: "America/New_York"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/report --weekly"]
+    resources:
+      limits:
+        cpu: "1"
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi

--- a/charts/cron/examples/pod-failure-policy.yaml
+++ b/charts/cron/examples/pod-failure-policy.yaml
@@ -1,0 +1,29 @@
+# Use a podFailurePolicy to react to specific failure modes instead of blindly retrying:
+# fail the whole job immediately on a non-retriable application exit code, and ignore failures
+# caused by the node being drained (so they don't count against backoffLimit).
+image:
+  repository: myrepo/worker
+  tag: "v1.2.3"
+  pullPolicy: IfNotPresent
+
+cronjobs:
+  import:
+    schedule: "15 * * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/import"]
+    job:
+      backoffLimit: 6
+      restartPolicy: Never
+      podFailurePolicy:
+        rules:
+          # Exit code 42 means "bad input" — don't retry, fail the job.
+          - action: FailJob
+            onExitCodes:
+              containerName: import
+              operator: In
+              values: [42]
+          # Pod evicted by node drain — don't count it against backoffLimit.
+          - action: Ignore
+            onPodConditions:
+              - type: DisruptionTarget
+                status: "True"

--- a/charts/cron/examples/security-hardened.yaml
+++ b/charts/cron/examples/security-hardened.yaml
@@ -1,0 +1,74 @@
+# A security-hardened cronjob: Restricted Pod Security Standards, no mounted SA token, a
+# default-deny-then-allow-DNS-and-HTTPS NetworkPolicy, External Secrets instead of inline
+# secrets, and minimal RBAC. Suitable for workloads under strict security requirements.
+image:
+  repository: myrepo/worker
+  tag: "v1.2.3"
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  automount: false
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop: ["ALL"]
+
+# Pull DB credentials from a secret store rather than committing them to values.
+externalSecrets:
+  - name: cron-db
+    refreshInterval: 1h
+    secretStoreRefName: gcp-secret-store
+    secretStoreRefKind: ClusterSecretStore
+    targetName: cron-db
+    dataKey: prod/cron/db
+
+# Minimal RBAC: allow the cron to read its own jobs.
+rbac:
+  enabled: true
+  rules:
+    - apiGroups: ["batch"]
+      resources: ["jobs"]
+      verbs: ["get", "list", "watch"]
+
+# Default-deny egress except DNS and HTTPS.
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+
+cronjobs:
+  reconcile:
+    schedule: "*/15 * * * *"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/reconcile"]
+    envFrom:
+      - secretRef:
+          name: cron-db
+    job:
+      backoffLimit: 3
+      activeDeadlineSeconds: 600

--- a/charts/cron/examples/single-cron.yaml
+++ b/charts/cron/examples/single-cron.yaml
@@ -1,0 +1,27 @@
+# A single scheduled job — the simplest useful configuration.
+# One CronJob that runs a cleanup task every night at 02:00 in a fixed time zone.
+image:
+  repository: myrepo/worker
+  tag: "v1.2.3"
+  pullPolicy: IfNotPresent
+
+env:
+  LOG_LEVEL: "info"
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+cronjobs:
+  nightly-cleanup:
+    schedule: "0 2 * * *"
+    timeZone: "America/New_York"
+    commands: ["/bin/sh"]
+    args: ["-c", "bin/cleanup --older-than=30d"]
+    job:
+      backoffLimit: 3
+      activeDeadlineSeconds: 1800

--- a/charts/cron/templates/NOTES.txt
+++ b/charts/cron/templates/NOTES.txt
@@ -1,0 +1,27 @@
+{{ include "cron.fullname" . }} installed.
+
+{{- if .Values.cronjobs }}
+
+CronJobs created in namespace {{ .Release.Namespace }}:
+{{- range $name, $job := .Values.cronjobs }}
+{{- $cfg := include "cron.merged" (dict "root" $ "job" $job) | fromYaml }}
+  - {{ printf "%s-%s" (include "cron.fullname" $) (include "cron.jobName" $name) | trunc 52 | trimSuffix "-" }}  (schedule: {{ $cfg.schedule | default "<unset>" }}{{ with $cfg.timeZone }}, tz: {{ . }}{{ end }})
+{{- end }}
+
+View them:
+  kubectl get cronjobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Inspect a schedule and recent runs:
+  kubectl describe cronjob -n {{ .Release.Namespace }} <name>
+  kubectl get jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Trigger a run immediately (without waiting for the schedule):
+  kubectl create job -n {{ .Release.Namespace }} <name>-manual --from=cronjob/<name>
+
+Tail the logs of the most recent run:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --tail=100 -f
+{{- else }}
+
+WARNING: no cronjobs are defined. Set `cronjobs.<name>.schedule` (and a command/args) in your
+values to create a CronJob. See the chart README for examples.
+{{- end }}

--- a/charts/cron/templates/_helpers.tpl
+++ b/charts/cron/templates/_helpers.tpl
@@ -1,0 +1,307 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cron.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cron.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cron.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cron.labels" -}}
+helm.sh/chart: {{ include "cron.chart" . }}
+{{ include "cron.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cron.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cron.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Normalize a cronjobs map key into a DNS-1123 label (lowercase alphanumerics and '-'),
+so resource names, container names, and label values are always valid regardless of how
+the key was written (e.g. "Nightly_Cleanup" -> "nightly-cleanup").
+*/}}
+{{- define "cron.jobName" -}}
+{{- $n := regexReplaceAll "[^a-z0-9]+" (lower .) "-" -}}
+{{- $n | trimAll "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cron.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cron.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" (default .Values.serviceAccount.name .Values.serviceAccountName) }}
+{{- end }}
+{{- end }}
+
+{{/*
+cron.merged — compute the effective configuration for a single cronjob entry.
+Takes a dict {root, job}. Returns YAML of the shared defaults deep-merged with the per-job
+override (the per-job value wins). Release-scoped keys (serviceAccount, helper resources, the
+cronjobs map itself) are excluded so they are never merged into an individual job.
+*/}}
+{{- define "cron.merged" -}}
+{{- $shared := omit .root.Values "nameOverride" "fullnameOverride" "serviceAccount" "configMaps" "externalSecrets" "pvc" "networkPolicy" "rbac" "cronjobs" -}}
+{{- merge (deepCopy .job) (deepCopy $shared) | toYaml -}}
+{{- end -}}
+
+{{/*
+cron.probe — render the body of a probe (httpGet|tcpSocket|exec|grpc + threshold fields).
+Takes the probe dict as the context. Used for native sidecar probes.
+*/}}
+{{- define "cron.probe" -}}
+{{- $probe := . -}}
+{{- if .httpGet }}
+httpGet:
+  {{- toYaml .httpGet | nindent 2 }}
+{{- else if .tcpSocket }}
+tcpSocket:
+  {{- toYaml .tcpSocket | nindent 2 }}
+{{- else if .exec }}
+exec:
+  {{- toYaml .exec | nindent 2 }}
+{{- else if .grpc }}
+grpc:
+  {{- toYaml .grpc | nindent 2 }}
+{{- end }}
+{{- range $field := list "initialDelaySeconds" "periodSeconds" "timeoutSeconds" "successThreshold" "failureThreshold" }}
+{{- if hasKey $probe $field }}
+{{ $field }}: {{ index $probe $field }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+cron.podSpec — render the pod template spec body for a cronjob.
+Takes a dict {root, cfg, name} where cfg is the merged configuration from cron.merged.
+*/}}
+{{- define "cron.podSpec" -}}
+{{- $root := .root -}}
+{{- $cfg := .cfg -}}
+{{- $name := .name -}}
+restartPolicy: {{ $cfg.job.restartPolicy | default "OnFailure" }}
+serviceAccountName: {{ $cfg.serviceAccountName | default (include "cron.serviceAccountName" $root) }}
+automountServiceAccountToken: {{ $root.Values.serviceAccount.automount }}
+{{- with $cfg.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $cfg.priorityClassName }}
+priorityClassName: {{ . }}
+{{- end }}
+{{- with $cfg.runtimeClassName }}
+runtimeClassName: {{ . }}
+{{- end }}
+{{- if not (kindIs "invalid" $cfg.terminationGracePeriodSeconds) }}
+terminationGracePeriodSeconds: {{ $cfg.terminationGracePeriodSeconds | int64 }}
+{{- end }}
+{{- with $cfg.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $cfg.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if or $cfg.sidecars $cfg.initContainer.enabled }}
+initContainers:
+  {{- range $sidecar := $cfg.sidecars }}
+  - name: {{ $sidecar.name }}
+    image: "{{ required (printf "sidecars[%s].image.repository is required" $sidecar.name) $sidecar.image.repository }}:{{ required (printf "sidecars[%s].image.tag is required" $sidecar.name) $sidecar.image.tag }}"
+    imagePullPolicy: {{ $sidecar.image.pullPolicy | default "IfNotPresent" }}
+    restartPolicy: Always
+    {{- with (or $sidecar.commands $sidecar.command) }}
+    command:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.args }}
+    args:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if or $sidecar.env $sidecar.secretEnv }}
+    env:
+    {{- range $sidecar.env }}
+      - name: {{ .name }}
+        {{- if hasKey . "value" }}
+        value: {{ .value | quote }}
+        {{- else if .valueFrom }}
+        valueFrom:
+          {{- toYaml .valueFrom | nindent 10 }}
+        {{- end }}
+    {{- end }}
+    {{- range $sidecar.secretEnv }}
+      - name: {{ .name }}
+        valueFrom:
+          {{- toYaml .valueFrom | nindent 10 }}
+    {{- end }}
+    {{- end }}
+    {{- with $sidecar.ports }}
+    ports:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.volumeMounts }}
+    volumeMounts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.startupProbe }}
+    startupProbe:
+      {{- include "cron.probe" . | trim | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.livenessProbe }}
+    livenessProbe:
+      {{- include "cron.probe" . | trim | nindent 6 }}
+    {{- end }}
+    {{- with $sidecar.readinessProbe }}
+    readinessProbe:
+      {{- include "cron.probe" . | trim | nindent 6 }}
+    {{- end }}
+  {{- end }}
+  {{- if $cfg.initContainer.enabled }}
+  - name: {{ $cfg.initContainer.name }}
+    image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag | default $root.Chart.AppVersion }}"
+    imagePullPolicy: {{ $cfg.image.pullPolicy }}
+    {{- with $cfg.initContainer.commands }}
+    command:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.initContainer.args }}
+    args:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if or $cfg.env $cfg.secretEnv }}
+    env:
+    {{- range $k, $v := $cfg.env }}
+      - name: {{ $k | quote }}
+        value: {{ $v | quote }}
+    {{- end }}
+    {{- range $k, $v := $cfg.secretEnv }}
+      - name: {{ $k | quote }}
+        valueFrom:
+          secretKeyRef:
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- with $cfg.initContainer.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.initContainer.volumeMounts }}
+    volumeMounts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+containers:
+  - name: {{ $name }}
+    image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag | default $root.Chart.AppVersion }}"
+    imagePullPolicy: {{ $cfg.image.pullPolicy }}
+    {{- with $cfg.commands }}
+    command:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.args }}
+    args:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.workingDir }}
+    workingDir: {{ . }}
+    {{- end }}
+    {{- with $cfg.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if or $cfg.env $cfg.secretEnv }}
+    env:
+    {{- range $k, $v := $cfg.env }}
+      - name: {{ $k | quote }}
+        value: {{ $v | quote }}
+    {{- end }}
+    {{- range $k, $v := $cfg.secretEnv }}
+      - name: {{ $k | quote }}
+        valueFrom:
+          secretKeyRef:
+          {{- range $kk, $vv := $v }}
+            {{ $kk }}: {{ $vv }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- with $cfg.envFrom }}
+    envFrom:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.lifecycle }}
+    lifecycle:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $cfg.volumeMounts }}
+    volumeMounts:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- with $cfg.volumes }}
+volumes:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $cfg.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $cfg.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $cfg.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/cron/templates/configmap.yaml
+++ b/charts/cron/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{- range $configmap := .Values.configMaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configmap.name }}
+  labels:
+    {{- include "cron.labels" $ | nindent 4 }}
+  {{- with $configmap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with $configmap.data }}
+data:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/cron/templates/cronjob.yaml
+++ b/charts/cron/templates/cronjob.yaml
@@ -1,0 +1,81 @@
+{{- $root := . -}}
+{{- range $name, $job := .Values.cronjobs }}
+{{- $cfg := include "cron.merged" (dict "root" $root "job" $job) | fromYaml }}
+{{- $j := $cfg.job }}
+{{- $jobName := include "cron.jobName" $name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ printf "%s-%s" (include "cron.fullname" $root) $jobName | trunc 52 | trimSuffix "-" }}
+  labels:
+    {{- include "cron.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: {{ $jobName | quote }}
+  {{- with $cfg.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ required (printf "cronjobs.%s: schedule is required (set it on the job or as a shared default)" $name) $cfg.schedule | quote }}
+  {{- with $cfg.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  concurrencyPolicy: {{ $cfg.concurrencyPolicy }}
+  suspend: {{ $cfg.suspend }}
+  {{- if not (kindIs "invalid" $cfg.startingDeadlineSeconds) }}
+  startingDeadlineSeconds: {{ $cfg.startingDeadlineSeconds | int64 }}
+  {{- end }}
+  successfulJobsHistoryLimit: {{ $cfg.successfulJobsHistoryLimit | int64 }}
+  failedJobsHistoryLimit: {{ $cfg.failedJobsHistoryLimit | int64 }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "cron.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: {{ $jobName | quote }}
+    spec:
+      {{- if not (kindIs "invalid" $j.backoffLimit) }}
+      backoffLimit: {{ $j.backoffLimit | int64 }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.ttlSecondsAfterFinished) }}
+      ttlSecondsAfterFinished: {{ $j.ttlSecondsAfterFinished | int64 }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.activeDeadlineSeconds) }}
+      activeDeadlineSeconds: {{ $j.activeDeadlineSeconds | int64 }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.parallelism) }}
+      parallelism: {{ $j.parallelism | int64 }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.completions) }}
+      completions: {{ $j.completions | int64 }}
+      {{- end }}
+      {{- if and $j.completionMode (ne $j.completionMode "NonIndexed") }}
+      completionMode: {{ $j.completionMode }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.backoffLimitPerIndex) }}
+      backoffLimitPerIndex: {{ $j.backoffLimitPerIndex | int64 }}
+      {{- end }}
+      {{- if not (kindIs "invalid" $j.maxFailedIndexes) }}
+      maxFailedIndexes: {{ $j.maxFailedIndexes | int64 }}
+      {{- end }}
+      {{- with $j.podReplacementPolicy }}
+      podReplacementPolicy: {{ . }}
+      {{- end }}
+      {{- with $j.podFailurePolicy }}
+      podFailurePolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      template:
+        metadata:
+          {{- with $cfg.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "cron.selectorLabels" $root | nindent 12 }}
+            app.kubernetes.io/component: {{ $jobName | quote }}
+            {{- with $cfg.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- include "cron.podSpec" (dict "root" $root "cfg" $cfg "name" $jobName) | nindent 10 }}
+{{- end }}

--- a/charts/cron/templates/external-secrets.yaml
+++ b/charts/cron/templates/external-secrets.yaml
@@ -1,0 +1,20 @@
+{{- range $es := .Values.externalSecrets }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $es.name }}
+  labels:
+    {{- include "cron.labels" $ | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval }}
+  secretStoreRef:
+    name: {{ $es.secretStoreRefName }}
+    kind: {{ $es.secretStoreRefKind | default "ClusterSecretStore" }}
+  target:
+    name: {{ $es.targetName }}
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: {{ $es.dataKey }}
+{{- end }}

--- a/charts/cron/templates/networkpolicy.yaml
+++ b/charts/cron/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cron.fullname" . }}
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "cron.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cron/templates/pvc.yaml
+++ b/charts/cron/templates/pvc.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.pvc.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.pvc.name | default (include "cron.fullname" .) }}
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+  {{- with .Values.pvc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- if .Values.pvc.accessModes }}
+    {{- toYaml .Values.pvc.accessModes | nindent 4 }}
+    {{- else }}
+    - ReadWriteOnce
+    {{- end }}
+  {{- with .Values.pvc.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.pvc.volumeMode }}
+  volumeMode: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.size | default "10Gi" }}
+  {{- with .Values.pvc.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cron/templates/rbac.yaml
+++ b/charts/cron/templates/rbac.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cron.fullname" . }}
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+{{- with .Values.rbac.rules }}
+rules:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cron.fullname" . }}
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cron.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cron.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/cron/templates/serviceaccount.yaml
+++ b/charts/cron/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cron.serviceAccountName" . }}
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/cron/templates/tests/test-image.yaml
+++ b/charts/cron/templates/tests/test-image.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cron.fullname" . }}-test-image"
+  labels:
+    {{- include "cron.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  restartPolicy: Never
+  containers:
+    - name: image-smoke
+      # Confirms the configured cron image is pullable and runnable in-cluster.
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: ["true"]

--- a/charts/cron/values.schema.json
+++ b/charts/cron/values.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Cron Helm Chart Values",
+  "description": "Schema for the cron chart values.yaml. Validates default values and example overrides.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "image": {
+      "type": "object",
+      "description": "Container image configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string", "description": "Container image repository." },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy.",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": { "type": "string", "description": "Image tag. Overrides the chart appVersion." }
+      }
+    },
+    "nullableInteger": {
+      "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
+    },
+    "job": {
+      "type": "object",
+      "description": "Job-level (jobTemplate.spec) configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "restartPolicy": {
+          "type": "string",
+          "description": "Pod restart policy for the job.",
+          "enum": ["OnFailure", "Never"]
+        },
+        "backoffLimit": { "$ref": "#/definitions/nullableInteger" },
+        "ttlSecondsAfterFinished": { "$ref": "#/definitions/nullableInteger" },
+        "activeDeadlineSeconds": { "$ref": "#/definitions/nullableInteger" },
+        "parallelism": { "$ref": "#/definitions/nullableInteger" },
+        "completions": { "$ref": "#/definitions/nullableInteger" },
+        "completionMode": {
+          "type": "string",
+          "description": "Job completion mode.",
+          "enum": ["NonIndexed", "Indexed"]
+        },
+        "backoffLimitPerIndex": { "$ref": "#/definitions/nullableInteger" },
+        "maxFailedIndexes": { "$ref": "#/definitions/nullableInteger" },
+        "podReplacementPolicy": {
+          "oneOf": [
+            { "type": "string", "enum": ["Failed", "TerminatingOrFailed"] },
+            { "type": "null" }
+          ]
+        },
+        "podFailurePolicy": { "type": "object", "description": "Pod failure policy rules." }
+      }
+    }
+  },
+  "properties": {
+    "image": { "$ref": "#/definitions/image" },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Secrets for pulling images from a private registry.",
+      "items": { "type": "object" }
+    },
+    "nameOverride": { "type": "string", "description": "Override the chart name." },
+    "fullnameOverride": { "type": "string", "description": "Override the fully qualified name." },
+    "serviceAccount": {
+      "type": "object",
+      "description": "ServiceAccount configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "automount": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "serviceAccountName": {
+      "type": "string",
+      "description": "Use a specific ServiceAccount name without creating one."
+    },
+    "annotations": { "type": "object", "description": "Annotations applied to every CronJob." },
+    "podAnnotations": { "type": "object", "description": "Annotations added to job pods." },
+    "podLabels": { "type": "object", "description": "Labels added to job pods." },
+    "podSecurityContext": { "type": "object", "description": "Pod-level security context." },
+    "securityContext": { "type": "object", "description": "Container-level security context." },
+    "commands": {
+      "type": "array",
+      "description": "Override the container entrypoint (command).",
+      "items": { "type": "string" }
+    },
+    "args": {
+      "type": "array",
+      "description": "Override the container args.",
+      "items": { "type": "string" }
+    },
+    "workingDir": { "type": "string", "description": "Working directory for the main container." },
+    "resources": { "type": "object", "description": "Resource limits and requests." },
+    "lifecycle": { "type": "object", "description": "Lifecycle hooks for the main container." },
+    "env": { "type": "object", "description": "Environment variables as key-value pairs." },
+    "secretEnv": {
+      "type": "object",
+      "description": "Environment variables sourced from existing secrets."
+    },
+    "envFrom": {
+      "type": "array",
+      "description": "Mount entire ConfigMaps or Secrets as environment variables.",
+      "items": { "type": "object" }
+    },
+    "volumes": {
+      "type": "array",
+      "description": "Additional volumes.",
+      "items": { "type": "object" }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts for the main container.",
+      "items": { "type": "object" }
+    },
+    "nodeSelector": { "type": "object", "description": "Node selector for pod scheduling." },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling.",
+      "items": { "type": "object" }
+    },
+    "affinity": { "type": "object", "description": "Affinity rules for pod scheduling." },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology spread constraints.",
+      "items": { "type": "object" }
+    },
+    "priorityClassName": { "type": "string", "description": "Pod priority class name." },
+    "runtimeClassName": { "type": "string", "description": "Runtime class (gVisor, Kata, etc.)." },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Termination grace period in seconds."
+    },
+    "initContainer": {
+      "type": "object",
+      "description": "One-shot init container configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "commands": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "resources": { "type": "object" },
+        "volumeMounts": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "sidecars": {
+      "type": "array",
+      "description": "Native sidecar containers (init containers with restartPolicy: Always).",
+      "items": { "type": "object" }
+    },
+    "schedule": {
+      "type": "string",
+      "description": "Default cron schedule used when a cronjob omits its own."
+    },
+    "timeZone": { "type": "string", "description": "IANA time zone for the schedule (1.27+)." },
+    "concurrencyPolicy": {
+      "type": "string",
+      "description": "How to treat concurrent runs.",
+      "enum": ["Allow", "Forbid", "Replace"]
+    },
+    "suspend": { "type": "boolean", "description": "Suspend the schedule." },
+    "startingDeadlineSeconds": { "$ref": "#/definitions/nullableInteger" },
+    "successfulJobsHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Completed jobs to retain."
+    },
+    "failedJobsHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Failed jobs to retain."
+    },
+    "job": { "$ref": "#/definitions/job" },
+    "cronjobs": {
+      "type": "object",
+      "description": "Map of cronjob name to its overrides. Each entry must resolve to a schedule.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Per-cronjob overrides; may set any shared key plus its own schedule."
+      }
+    },
+    "configMaps": {
+      "type": "array",
+      "description": "ConfigMaps to create.",
+      "items": { "type": "object" }
+    },
+    "externalSecrets": {
+      "type": "array",
+      "description": "External Secrets configuration.",
+      "items": { "type": "object" }
+    },
+    "pvc": {
+      "type": "object",
+      "description": "Persistent Volume Claim configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+          }
+        },
+        "size": {
+          "type": "string",
+          "description": "Storage size as a Kubernetes quantity.",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K|m)?$"
+        },
+        "storageClassName": { "type": "string" },
+        "volumeMode": { "type": "string" },
+        "selector": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "Network Policy configuration.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "policyTypes": { "type": "array", "items": { "type": "string" } },
+        "ingress": { "type": "array", "items": { "type": "object" } },
+        "egress": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "description": "RBAC Role + RoleBinding for the ServiceAccount.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "rules": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/cron/values.yaml
+++ b/charts/cron/values.yaml
@@ -1,0 +1,470 @@
+# Default values for cron.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+# This chart deploys one or more Kubernetes CronJobs from a single release. Every top-level key
+# below is a SHARED DEFAULT that applies to every entry in `cronjobs`. Each entry under `cronjobs`
+# may override any of these keys for that one job. Overrides are deep-merged over the shared
+# defaults (per-job value wins; maps such as `env` are merged key-by-key, lists are replaced).
+#
+# Minimal usage:
+#   image:
+#     repository: myrepo/worker
+#     tag: v1.2.3
+#   cronjobs:
+#     nightly-cleanup:
+#       schedule: "0 2 * * *"
+#       commands: ["/bin/sh"]
+#       args: ["-c", "bin/cleanup"]
+
+## @section Image parameters
+##
+
+## Container image shared by every cronjob (override per-job under cronjobs.<name>.image)
+## More information: https://kubernetes.io/docs/concepts/containers/images/
+## @param image.repository Container image repository
+## @param image.pullPolicy Image pull policy (Always, IfNotPresent, Never)
+## @param image.tag Image tag (overrides the chart appVersion if set)
+##
+image:
+  repository: busybox
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # NOTE: Using "latest" is not recommended for production. Use specific version tags.
+  tag: "1.36"
+
+## @param imagePullSecrets Kubernetes secret names for pulling private images
+## https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## Example:
+## imagePullSecrets:
+##   - name: myregistrykey
+##
+imagePullSecrets: []
+
+## @section Global parameters
+##
+
+## @param nameOverride Override the chart name
+##
+nameOverride: ""
+
+## @param fullnameOverride Override the full name of resources
+##
+fullnameOverride: ""
+
+## @section Service Account parameters
+##
+
+## ServiceAccount used by every cronjob pod (release-scoped — one ServiceAccount per release).
+## A pod can opt into a different one with cronjobs.<name>.serviceAccountName.
+## https://kubernetes.io/docs/concepts/security/service-accounts/
+## @param serviceAccount.create Specifies whether a service account should be created
+## @param serviceAccount.automount Automatically mount the ServiceAccount's API credentials
+## @param serviceAccount.annotations Annotations to add to the service account (e.g. IRSA / Workload Identity)
+## @param serviceAccount.name Name of the service account (generated from the fullname template if empty)
+##
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+## @param serviceAccountName Use a specific ServiceAccount name for pods without creating one (overridable per-job)
+##
+serviceAccountName: ""
+
+## @section Pod metadata parameters
+##
+
+## @param annotations Annotations applied to every CronJob resource's metadata
+##
+annotations: {}
+
+## @param podAnnotations Annotations added to every job pod
+## https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## @param podLabels Labels added to every job pod
+##
+podLabels: {}
+
+## @section Security parameters
+##
+
+## @param podSecurityContext Pod-level security context
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+## Example:
+## podSecurityContext:
+##   runAsNonRoot: true
+##   runAsUser: 65534
+##   fsGroup: 65534
+##   seccompProfile:
+##     type: RuntimeDefault
+##
+podSecurityContext: {}
+
+## @param securityContext Container-level security context for the main job container
+## Example:
+## securityContext:
+##   allowPrivilegeEscalation: false
+##   readOnlyRootFilesystem: true
+##   runAsNonRoot: true
+##   runAsUser: 65534
+##   capabilities:
+##     drop:
+##       - ALL
+##
+securityContext: {}
+
+## @section Container parameters
+##
+
+## Override the container entrypoint (command) and its arguments. Most cronjobs set `args`
+## (and sometimes `commands`) per-job under cronjobs.<name>.
+## @param commands Override the container entrypoint
+## @param args Override the container arguments
+## Example:
+## commands: ["/bin/sh"]
+## args: ["-c", "echo hello"]
+##
+commands: []
+args: []
+
+## @param workingDir Working directory for the main container
+##
+workingDir: ""
+
+## @param resources Resource limits and requests for the main job container. Always set these in production
+## https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+## Example:
+## resources:
+##   limits:
+##     cpu: 500m
+##     memory: 512Mi
+##   requests:
+##     cpu: 100m
+##     memory: 128Mi
+##
+resources: {}
+
+## @param lifecycle Lifecycle hooks for the main container
+## https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+##
+lifecycle: {}
+
+## @param env Environment variables as key-value pairs
+## Example:
+## env:
+##   LOG_LEVEL: "info"
+##   BATCH_SIZE: "1000"
+##
+env: {}
+
+## @param secretEnv Environment variables sourced from existing secrets (created outside this chart)
+## Example:
+## secretEnv:
+##   DATABASE_PASSWORD:
+##     name: db-secret
+##     key: password
+##
+secretEnv: {}
+
+## @param envFrom Mount entire ConfigMaps or Secrets as environment variables
+## Example:
+## envFrom:
+##   - configMapRef:
+##       name: cron-config
+##   - secretRef:
+##       name: cron-secrets
+##
+envFrom: []
+
+## @section Storage parameters
+##
+
+## Additional volumes and mounts available to the main container, init container, and sidecars.
+## https://kubernetes.io/docs/concepts/storage/volumes/
+## @param volumes Additional volumes for the pod
+## @param volumeMounts Additional volume mounts for the main container
+## Example:
+## volumes:
+##   - name: tmp
+##     emptyDir: {}
+## volumeMounts:
+##   - name: tmp
+##     mountPath: /tmp
+##
+volumes: []
+volumeMounts: []
+
+## @section Scheduling parameters
+##
+
+## @param nodeSelector Node labels for pod assignment
+##
+nodeSelector: {}
+
+## @param tolerations Tolerations for pod assignment
+##
+tolerations: []
+
+## @param affinity Affinity rules for pod assignment
+##
+affinity: {}
+
+## @param topologySpreadConstraints Topology spread constraints for pod assignment
+## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
+## @param priorityClassName Pod priority class name
+## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+##
+priorityClassName: ""
+
+## @param runtimeClassName Runtime class name (gVisor, Kata, etc.)
+## https://kubernetes.io/docs/concepts/containers/runtime-class/
+##
+runtimeClassName: ""
+
+## @param terminationGracePeriodSeconds Grace period before a job pod is force-killed, in seconds
+##
+terminationGracePeriodSeconds: 30
+
+## @section Init container parameters
+##
+
+## One-shot init container that must complete before the main container starts (e.g. migrations).
+## It reuses the cronjob's image and the shared env/secretEnv.
+## https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## @param initContainer.enabled Enable the one-shot init container
+## @param initContainer.name Init container name
+## @param initContainer.commands Override the init container entrypoint (the image is the cronjob's image)
+## @param initContainer.args Override the init container arguments
+## @param initContainer.resources Resource limits and requests for the init container
+## @param initContainer.volumeMounts Volume mounts for the init container
+##
+initContainer:
+  enabled: false
+  name: init
+  commands: []
+  args: []
+  resources: {}
+  volumeMounts: []
+
+## @section Sidecar parameters
+##
+
+## @param sidecars Sidecar containers, rendered as NATIVE sidecars (init containers with restartPolicy: Always)
+## Native sidecars are the correct pattern for Jobs: they keep running while the main container
+## works, then are terminated automatically so the Job can complete (a plain sidecar would keep
+## the Job running forever). Requires Kubernetes 1.29+.
+## https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+## Example:
+## sidecars:
+##   - name: cloud-sql-proxy
+##     image:
+##       # repository and tag are both REQUIRED for sidecars (no implicit default).
+##       repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+##       tag: "2.11"
+##       pullPolicy: IfNotPresent
+##     # commands (preferred, matches the main container) or command both set the entrypoint.
+##     commands: []
+##     args: ["--port=5432", "my-project:us-central1:my-instance"]
+##     env: []
+##     secretEnv: []
+##     ports: []
+##     resources: {}
+##     securityContext: {}
+##     volumeMounts: []
+##     # Probes (httpGet | tcpSocket | exec | grpc) are supported for native sidecars.
+##     startupProbe: {}
+##     livenessProbe: {}
+##     readinessProbe: {}
+##
+sidecars: []
+
+## @section CronJob scheduling parameters
+##
+## Shared CronJob defaults. Every field below can be overridden per-job.
+## https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+
+## @param schedule Default cron schedule used when a cronjob omits its own
+## Every cronjob must resolve to a non-empty schedule, either here or per-job.
+##
+schedule: ""
+
+## @param timeZone IANA time zone for the schedule, e.g. "America/New_York"
+##
+timeZone: ""
+
+## @param concurrencyPolicy How to treat concurrent runs (Allow, Forbid, Replace)
+##
+concurrencyPolicy: Forbid
+
+## @param suspend Suspend the schedule (no new jobs are created while true)
+##
+suspend: false
+
+## @param startingDeadlineSeconds Deadline for starting a job if it misses its scheduled time (null = no deadline)
+##
+startingDeadlineSeconds: null
+
+## @param successfulJobsHistoryLimit How many completed jobs to retain in history
+## @param failedJobsHistoryLimit How many failed jobs to retain in history
+##
+successfulJobsHistoryLimit: 3
+failedJobsHistoryLimit: 1
+
+## @section Job parameters
+##
+
+## Job-level defaults (jobTemplate.spec). Overridable per-job under cronjobs.<name>.job.
+## https://kubernetes.io/docs/concepts/workloads/controllers/job/
+## @param job.restartPolicy Restart policy for job pods (OnFailure or Never; Always is not valid for Jobs)
+## @param job.backoffLimit Number of retries before the job is marked failed
+## @param job.ttlSecondsAfterFinished Auto-clean finished jobs this many seconds after completion (null = keep)
+## @param job.activeDeadlineSeconds Hard wall-clock limit for a single job run, in seconds (null = none)
+## @param job.parallelism Number of pods running in parallel (null = default of 1)
+## @param job.completions Number of successful completions required (null = default of 1)
+## @param job.completionMode Job completion mode (NonIndexed or Indexed; Indexed gives each pod a JOB_COMPLETION_INDEX)
+## @param job.backoffLimitPerIndex Per-index retry limit for Indexed jobs (null = unset)
+## @param job.maxFailedIndexes Maximum failed indexes before an Indexed job fails (null = unset)
+## @param job.podReplacementPolicy When to create replacement pods (Failed or TerminatingOrFailed; null = unset)
+## @param job.podFailurePolicy Fine-grained handling of pod failures (empty = unset)
+## https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-failure-policy
+## Example:
+## job:
+##   podFailurePolicy:
+##     rules:
+##       - action: FailJob
+##         onExitCodes:
+##           operator: In
+##           values: [42]
+##
+job:
+  restartPolicy: OnFailure
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 3600
+  activeDeadlineSeconds: null
+  parallelism: null
+  completions: null
+  completionMode: NonIndexed
+  backoffLimitPerIndex: null
+  maxFailedIndexes: null
+  podReplacementPolicy: null
+  podFailurePolicy: {}
+
+## @section CronJobs
+##
+
+## @param cronjobs Map of <name> -> per-cronjob overrides. Each name produces one CronJob named "<release-fullname>-<name>"
+## An entry need only set `schedule` plus whatever it overrides from the shared defaults above.
+## Example:
+## cronjobs:
+##   nightly-cleanup:
+##     schedule: "0 2 * * *"
+##     commands: ["/bin/sh"]
+##     args: ["-c", "bin/cleanup --older-than=30d"]
+##     # any shared key can be overridden here:
+##     resources:
+##       limits: { cpu: 500m, memory: 256Mi }
+##     env:
+##       BATCH_SIZE: "1000"
+##     job:
+##       backoffLimit: 3
+##   hourly-sync:
+##     schedule: "0 * * * *"
+##     concurrencyPolicy: Replace
+##     args: ["-c", "bin/sync"]
+##
+cronjobs: {}
+
+## @section Helper resources
+##
+## Release-scoped resources, created once per release rather than per cronjob.
+
+## @param configMaps ConfigMaps to create
+## https://kubernetes.io/docs/concepts/configuration/configmap/
+## Example:
+## configMaps:
+##   - name: cron-config
+##     annotations: {}
+##     data:
+##       config.yaml: |
+##         key: value
+##
+configMaps: []
+
+## @param externalSecrets External Secrets to create (requires the External Secrets Operator)
+## Example:
+## externalSecrets:
+##   - name: cron-secret
+##     refreshInterval: 1h
+##     secretStoreRefName: cluster-secret-store
+##     secretStoreRefKind: ClusterSecretStore
+##     targetName: cron-secret
+##     dataKey: path/to/secret
+##
+externalSecrets: []
+
+## Persistent Volume Claim shared by the cronjob pods (e.g. for a shared work directory).
+## https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+## @param pvc.enabled Create a PersistentVolumeClaim
+## @param pvc.name PVC name (defaults to the fullname template)
+## @param pvc.annotations Annotations to add to the PVC
+## @param pvc.accessModes Access modes for the PVC
+## @param pvc.size Storage size to request
+## @param pvc.storageClassName Storage class (uses the cluster default if empty)
+## @param pvc.volumeMode Volume mode (Filesystem or Block)
+## @param pvc.selector Label selector to bind a specific volume
+##
+pvc:
+  enabled: false
+  name: ""
+  annotations: {}
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  storageClassName: ""
+  volumeMode: Filesystem
+  selector: {}
+
+## Network Policy applied to the cronjob pods.
+## https://kubernetes.io/docs/concepts/services-networking/network-policies/
+## @param networkPolicy.enabled Create a NetworkPolicy for the cronjob pods
+## @param networkPolicy.policyTypes Policy types to enforce (Ingress, Egress)
+## @param networkPolicy.ingress Ingress rules
+## @param networkPolicy.egress Egress rules
+## Example:
+## networkPolicy:
+##   egress:
+##     - to:
+##         - namespaceSelector: {}
+##       ports:
+##         - protocol: TCP
+##           port: 443
+##
+networkPolicy:
+  enabled: false
+  policyTypes:
+    - Egress
+  ingress: []
+  egress: []
+
+## RBAC for the ServiceAccount. Crons often need namespaced API access (e.g. to trigger or read
+## other resources). Creates a Role + RoleBinding bound to the chart's ServiceAccount.
+## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+## @param rbac.enabled Create a Role and RoleBinding for the ServiceAccount
+## @param rbac.rules Role rules
+## Example:
+## rbac:
+##   rules:
+##     - apiGroups: ["batch"]
+##       resources: ["jobs"]
+##       verbs: ["create", "get", "list"]
+##
+rbac:
+  enabled: false
+  rules: []


### PR DESCRIPTION
Closes #18.

Adds `charts/cron` at `0.1.0`. One release defines **many CronJobs** that share a common pod spec, with per-job overrides — so a set of related crons no longer means one release per cron, or hand-written manifests with no schema, examples, or CI coverage.

## Design

Every top-level key in `values.yaml` is a **shared default**. Each entry under `cronjobs` is a named CronJob (`<release-fullname>-<name>`) that may override any shared key. Overrides deep-merge: per-job value wins, maps like `env` merge key-by-key, lists like `args`/`sidecars` replace wholesale.

```yaml
image: { repository: myrepo/worker, tag: v1.2.3 }
env:
  LOG_LEVEL: info          # shared by every cron

cronjobs:
  nightly-cleanup:
    schedule: "0 2 * * *"
    args: ["-c", "bin/cleanup"]
  hourly-sync:
    schedule: "0 * * * *"
    concurrencyPolicy: Replace
    env:
      BATCH_SIZE: "1000"   # merged on top of the shared env
```

Verified in the rendered output: `hourly-sync` gets `concurrencyPolicy: Replace` and the merged `BATCH_SIZE` while `nightly-cleanup` inherits the shared `Forbid` and env.

## What's covered

- **CronJob** — `schedule`, `timeZone`, `concurrencyPolicy` (defaults to `Forbid`, not the Kubernetes default of `Allow`), `suspend`, `startingDeadlineSeconds`, history limits.
- **Job** — `restartPolicy`, `backoffLimit`, `ttlSecondsAfterFinished`, `activeDeadlineSeconds`, `parallelism`, `completions`, `completionMode`, `backoffLimitPerIndex`, `maxFailedIndexes`, `podReplacementPolicy`, `podFailurePolicy`.
- **Pod spec** — image, command/args, `env`/`secretEnv`/`envFrom`, resources, security contexts, volumes, lifecycle, nodeSelector, tolerations, affinity, topology spread, priority/runtime class, grace period.
- **Native sidecars** — rendered as init containers with `restartPolicy: Always`. This is the only pattern that lets a Job with a long-running helper complete; a plain sidecar would keep it Running forever. Plus a one-shot init container for migrations.
- **Release-scoped helpers** — ServiceAccount, optional RBAC, ConfigMaps, External Secrets, PVC, NetworkPolicy.

## Adapted to this repo, not copied

Ported from an internal chart of the same design, reworked to match `AGENTS.md`: `@param`-documented `values.yaml`, examples named without the `-values` suffix, no `ci/` dir (CI already renders every example), MIT + `etowett` metadata.

Three deliberate changes over the source, rather than carrying them over:

- **`kubeVersion: ">=1.29.0-0"`**, not `1.27`. The source declares a 1.27 floor while rendering native sidecars unconditionally — those need 1.29. This also matches `charts/app` and CI.
- **`NOTES.txt` prints the normalized job name.** It used the raw map key, so a key like `Nightly_Cleanup` printed `my-crons-Nightly_Cleanup` — a resource that was never created (the CronJob is `my-crons-nightly-cleanup`). Now both agree.
- **`app.kubernetes.io/component: <name>`** replaces the source's vendor-specific `cron.ello.com/name`, matching what `charts/app` already uses for its Celery components. Lets you select one cron's jobs: `-l app.kubernetes.io/component=nightly-cleanup`.

## Examples

`single-cron`, `multi-cron-shared`, `indexed-parallel-job` (Indexed sharding + a Cloud SQL proxy native sidecar), `pod-failure-policy`, `security-hardened`. All CI-rendered and kubeconform-validated.

## Verification

- `make check` — lint + render every example, both charts: **pass**
- `make validate` — kubeconform `-strict` on defaults + every example across k8s 1.33/1.34/1.35/1.36: **exit 0, 64 resource sets, 0 invalid** (1 skip is the ExternalSecret CRD, which has no published schema)
- Schema guards confirmed to actually fire: `concurrencyPolicy=Sometimes` → rejected against the enum; an unknown top-level key → rejected (the schema is closed at the root, so typos fail at render rather than being silently ignored); a cronjob with no `schedule` → named error naming the offending job.
- Default render (`cronjobs: {}`) produces just the ServiceAccount and the Helm test pod, so `ct install` has something valid to install and test.

`ct lint` was not run locally (`ct` isn't installed on this machine) — CI covers it, along with the kind install on 1.33–1.35.

## Note, out of scope for this PR

The repo has no `.gitignore`, so the `bin/` that `make install-kubeconform` creates — and the `dist/` from `make package` — show up as untracked and are easy to commit by accident. I left it alone per the "don't add features beyond the task" rule; worth a follow-up if you agree.