### PR TITLE
chore: add .gitignore for Makefile build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Local tooling and build artifacts. These are what `make clean` removes:
+# `make install-kubeconform` (pulled in by `make validate`) writes to /bin,
+# and `make package` writes to /dist. Paths are anchored to the repo root so
+# they never mask something inside charts/.
+/bin/
+/dist/
+*.tgz
+
+# Local agent configuration (per-machine, not shared).
+.claude/settings.local.json


### PR DESCRIPTION
Closes #20. Follow-up to #19, where `bin/` showed up untracked after running the documented pre-PR gate and had to be manually kept out of the commit.

## Why

Two `make` targets from AGENTS.md's pre-PR workflow write into the working tree:

- `make install-kubeconform` (pulled in by `make validate`) → `./bin/` (`LOCAL_BIN := $(CURDIR)/bin`)
- `make package` → `./dist/` (`PKG_DIR := dist`)

`make clean` already treats both as disposable (`rm -rf $(PKG_DIR) $(LOCAL_BIN)`) — nothing stopped them being staged first. A stray `git add .` would commit a platform-specific binary.

## What's in it

```
/bin/
/dist/
*.tgz
.claude/settings.local.json
```

- **Anchored paths** (`/bin/`, not `bin/`) so the rules only match the repo root and can't mask anything under `charts/`.
- **`.claude/settings.local.json`** was previously excluded only by a per-machine global ignore (`~/.config/git/ignore`), so the protection didn't travel with the repo — a fresh clone on another machine would see it as untracked. Now it's self-contained.
- **Deliberately minimal.** No `.env`, editor, or OS patterns: this repo doesn't produce those, and AGENTS.md says not to add beyond the task. The file describes this repo's real artifacts rather than being a generic template.

## Verification

Ran the targets rather than assuming the globs match:

- `make package` → produced `dist/app-1.5.1.tgz` and `dist/cron-0.1.0.tgz`; `git status` then showed only `.gitignore` itself.
- `make validate` → exit 0, reinstalled `bin/kubeconform`; `git status` again showed only `.gitignore`.
- `git ls-files | git check-ignore --stdin` → **no output**, confirming no currently-tracked file becomes ignored by these rules.
